### PR TITLE
Refactor API client and helper utilities

### DIFF
--- a/api/civitai.py
+++ b/api/civitai.py
@@ -1,40 +1,166 @@
-# ================================================
-# File: api/civitai.py
-# ================================================
-import requests
+"""Utilities for interacting with the Civitai API and Meilisearch."""
+from __future__ import annotations
+
 import json
-from typing import List, Optional, Dict, Any, Union
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Optional, Union
+from urllib.parse import urljoin
+
+import requests
+
+JSONDict = Dict[str, Any]
+ResponseType = Union[JSONDict, requests.Response, None]
+
+_MEILI_FACETS = (
+    "category.name",
+    "checkpointType",
+    "fileFormats",
+    "lastVersionAtUnix",
+    "tags.name",
+    "type",
+    "user.username",
+    "version.baseModel",
+    "nsfwLevel",
+)
+
+_MEILI_SORT_MAP = {
+    "Relevancy": None,
+    "Most Downloaded": "metrics.downloadCount:desc",
+    "Highest Rated": "metrics.thumbsUpCount:desc",
+    "Most Liked": "metrics.favoriteCount:desc",
+    "Most Discussed": "metrics.commentCount:desc",
+    "Most Collected": "metrics.collectedCount:desc",
+    "Most Buzz": "metrics.tippedAmountCount:desc",
+    "Newest": "createdAt:desc",
+}
+
+_MEILI_TOKEN = (
+    "Bearer "
+    "8c46eb2508e21db1e9828a97968d91ab1ca1caa5f70a00e88a2ba1e286603b61"
+)
+
+
+@dataclass
+class _MeiliQuery:
+    """Represents a single Meilisearch query payload."""
+
+    query: Optional[str] = ""
+    types: Optional[Iterable[str]] = None
+    base_models: Optional[Iterable[str]] = None
+    sort: Optional[str] = None
+    limit: int = 20
+    page: int = 1
+    nsfw: Optional[bool] = None
+
+    def __post_init__(self) -> None:
+        self.limit = self._clamp(self.limit, 1, 100)
+        self.page = max(1, int(self.page or 1))
+
+    @staticmethod
+    def _clamp(value: Any, low: int, high: int) -> int:
+        with suppress(TypeError, ValueError):
+            return max(low, min(high, int(value)))
+        return low
+
+    @staticmethod
+    def _clean_iterable(values: Optional[Iterable[str]]) -> tuple[str, ...]:
+        if not values:
+            return ()
+        if isinstance(values, (str, bytes)):
+            values = [values]
+        cleaned = []
+        seen = set()
+        for value in values:
+            text = str(value).strip()
+            if text and text not in seen:
+                cleaned.append(text)
+                seen.add(text)
+        return tuple(cleaned)
+
+    @property
+    def offset(self) -> int:
+        return max(0, (self.page - 1) * self.limit)
+
+    def payload(self) -> JSONDict:
+        filters = []
+        type_filters = [f'"type"="{t}"' for t in self._clean_iterable(self.types)]
+        base_filters = [
+            f'"version.baseModel"="{bm}"' for bm in self._clean_iterable(self.base_models)
+        ]
+        if type_filters:
+            filters.append(type_filters)
+        if base_filters:
+            filters.append(base_filters)
+        if not self.nsfw:
+            filters.append("nsfwLevel IN [1, 2, 4]")
+        filters.append("availability = Public")
+
+        query: JSONDict = {
+            "q": (self.query or ""),
+            "indexUid": "models_v9",
+            "facets": list(_MEILI_FACETS),
+            "attributesToHighlight": [],
+            "highlightPreTag": "__ais-highlight__",
+            "highlightPostTag": "__/ais-highlight__",
+            "limit": self.limit,
+            "offset": self.offset,
+            "filter": filters,
+        }
+        if self.sort:
+            query["sort"] = [self.sort]
+        return {"queries": [query]}
+
 
 class CivitaiAPI:
-    """Simple wrapper for interacting with the Civitai API v1."""
-    BASE_URL = "https://civitai.com/api/v1"
+    """Lightweight wrapper for the Civitai REST API and Meilisearch."""
 
-    def __init__(self, api_key: Optional[str] = None):
+    BASE_URL = "https://civitai.com/api/v1"
+    MEILI_URL = "https://search.civitai.com/multi-search"
+
+    def __init__(self, api_key: Optional[str] = None, session: Optional[requests.Session] = None):
         self.api_key = api_key
-        self.base_headers = {'Content-Type': 'application/json'}
+        self.session = session or requests.Session()
+        self.base_headers: Dict[str, str] = {"Content-Type": "application/json"}
         if api_key:
             self.base_headers["Authorization"] = f"Bearer {api_key}"
-            print("[Civitai API] Using API Key.")
-        else:
-            print("[Civitai API] No API Key provided.")
 
-    def _get_request_headers(self, method: str, has_json_data: bool) -> Dict[str, str]:
-        """Returns headers for a specific request."""
-        headers = self.base_headers.copy()
-        # Don't send content-type for GET/HEAD if no json_data
-        if method.upper() in ["GET", "HEAD"] and not has_json_data:
-            headers.pop('Content-Type', None)
-        return headers
+    # ------------------------------------------------------------------
+    # Internal utilities
+    # ------------------------------------------------------------------
+    def _error(self, message: str, status_code: Optional[int] = None, details: Any = None) -> JSONDict:
+        return {"error": message, "status_code": status_code, "details": details}
 
-    def _request(self, method: str, endpoint: str, params: Optional[Dict] = None,
-                 json_data: Optional[Dict] = None, stream: bool = False,
-                 allow_redirects: bool = True, timeout: int = 30) -> Union[Dict[str, Any], requests.Response, None]:
-        """Makes a request to the Civitai API and handles basic errors."""
-        url = f"{self.BASE_URL}/{endpoint.lstrip('/')}"
-        request_headers = self._get_request_headers(method, json_data is not None)
+    @staticmethod
+    def _response_details(response: Optional[requests.Response]) -> Any:
+        if response is None:
+            return None
+        with suppress(ValueError, json.JSONDecodeError):
+            return response.json()
+        text = getattr(response, "text", "") or ""
+        return text[:200]
 
+    def _send(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: Optional[JSONDict] = None,
+        json_data: Optional[JSONDict] = None,
+        stream: bool = False,
+        headers: Optional[Dict[str, str]] = None,
+        allow_redirects: bool = True,
+        timeout: int = 30,
+    ) -> ResponseType:
+        request_headers = dict(self.base_headers)
+        if headers:
+            request_headers.update(headers)
+        if method.upper() in {"GET", "HEAD"} and json_data is None:
+            request_headers.pop("Content-Type", None)
+
+        response: Optional[requests.Response] = None
         try:
-            response = requests.request(
+            response = self.session.request(
                 method,
                 url,
                 headers=request_headers,
@@ -42,214 +168,117 @@ class CivitaiAPI:
                 json=json_data,
                 stream=stream,
                 allow_redirects=allow_redirects,
-                timeout=timeout
+                timeout=timeout,
             )
-            response.raise_for_status()  # Raise HTTPError for bad responses (4xx or 5xx)
-
+            response.raise_for_status()
             if stream:
-                return response  # Return the response object for streaming
-
-            # Handle No Content response (e.g., 204)
+                return response
             if response.status_code == 204 or not response.content:
                 return None
-
             return response.json()
+        except requests.exceptions.HTTPError as exc:
+            response = exc.response or response
+            status = response.status_code if response is not None else None
+            return self._error(
+                f"HTTP Error: {status}",
+                status,
+                self._response_details(response),
+            )
+        except requests.exceptions.RequestException as exc:
+            return self._error(str(exc))
+        except ValueError:
+            status = response.status_code if response is not None else None
+            detail = response.text[:200] if response is not None else "N/A"
+            return self._error("Invalid JSON response", status, detail)
 
-        except requests.exceptions.HTTPError as http_err:
-            error_detail = None
-            status_code = http_err.response.status_code
-            try:
-                error_detail = http_err.response.json()
-            except json.JSONDecodeError:
-                error_detail = http_err.response.text[:200] # First 200 chars
-            print(f"Civitai API HTTP Error ({method} {url}): Status {status_code}, Response: {error_detail}")
-            # Return a structured error dictionary
-            return {"error": f"HTTP Error: {status_code}", "details": error_detail, "status_code": status_code}
+    def _request(self, method: str, endpoint: str, **kwargs: Any) -> ResponseType:
+        url = urljoin(f"{self.BASE_URL}/", endpoint.lstrip("/"))
+        return self._send(method, url, **kwargs)
 
-        except requests.exceptions.RequestException as req_err:
-            print(f"Civitai API Request Error ({method} {url}): {req_err}")
-            return {"error": str(req_err), "details": None, "status_code": None}
+    # ------------------------------------------------------------------
+    # Public API methods
+    # ------------------------------------------------------------------
+    def get_model_info(self, model_id: int) -> ResponseType:
+        return self._request("GET", f"/models/{model_id}")
 
-        except json.JSONDecodeError as json_err:
-            print(f"Civitai API Error: Failed to decode JSON response from {url}: {json_err}")
-            # Include response text if possible and not streaming
-            response_text = response.text[:200] if not stream and hasattr(response, 'text') else "N/A"
-            return {"error": "Invalid JSON response", "details": response_text, "status_code": response.status_code if hasattr(response, 'status_code') else None}
+    def get_model_version_info(self, version_id: int) -> ResponseType:
+        return self._request("GET", f"/model-versions/{version_id}")
 
-    def get_model_info(self, model_id: int) -> Optional[Dict[str, Any]]:
-        """Gets information about a model by its ID. (GET /models/{id})"""
-        endpoint = f"/models/{model_id}"
-        result = self._request("GET", endpoint)
-        # Check if the result is an error dictionary
-        if isinstance(result, dict) and "error" in result:
-            return result # Propagate error dict
-        return result # Return model info dict or None
-
-    def get_model_version_info(self, version_id: int) -> Optional[Dict[str, Any]]:
-        """Gets information about a specific model version by its ID. (GET /model-versions/{id})"""
-        endpoint = f"/model-versions/{version_id}"
-        result = self._request("GET", endpoint)
-        if isinstance(result, dict) and "error" in result:
-            return result
-        return result
-
-    def search_models(self, query: str, types: Optional[List[str]] = None,
-                      sort: str = 'Highest Rated', period: str = 'AllTime',
-                      limit: int = 20, page: int = 1,
-                      nsfw: Optional[bool] = None) -> Optional[Dict[str, Any]]:
-        """Searches for models on Civitai. (GET /models)"""
-        endpoint = "/models"
-        params = {
-            "limit": max(1, min(100, limit)), # Ensure limit is reasonable
-            "page": max(1, page),
+    def search_models(
+        self,
+        query: str,
+        types: Optional[Iterable[str]] = None,
+        sort: str = "Highest Rated",
+        period: str = "AllTime",
+        limit: int = 20,
+        page: int = 1,
+        nsfw: Optional[bool] = None,
+    ) -> ResponseType:
+        limit = _MeiliQuery._clamp(limit, 1, 100)
+        page = max(1, int(page or 1))
+        params: JSONDict = {
+            "limit": limit,
+            "page": page,
             "query": query,
             "sort": sort,
-            "period": period
+            "period": period,
         }
         if types:
-            # `requests` handles lists by appending multiple key=value pairs,
-            # which matches the expectation for 'array' type in the API doc.
-             params["types"] = types
+            params["types"] = list(types)
         if nsfw is not None:
-            params["nsfw"] = str(nsfw).lower() # API expects string "true" or "false"
+            params["nsfw"] = str(nsfw).lower()
 
-        result = self._request("GET", endpoint, params=params)
+        result = self._request("GET", "/models", params=params)
         if isinstance(result, dict) and "error" in result:
             return result
-        # Ensure structure is as expected before returning
-        if isinstance(result, dict) and "items" in result and "metadata" in result:
-             return result
-        else:
-             print(f"Warning: Unexpected search result format: {result}")
-             # Return a consistent empty structure on unexpected format
-             return {"items": [], "metadata": {"totalItems": 0, "currentPage": page, "pageSize": limit, "totalPages": 0}}
-        
-    def search_models_meili(self, query: str, types: Optional[List[str]] = None,
-                            base_models: Optional[List[str]] = None,
-                            sort: str = 'metrics.downloadCount:desc', # Default to Most Downloaded
-                            limit: int = 20, page: int = 1,
-                            nsfw: Optional[bool] = None) -> Optional[Dict[str, Any]]:
-        """Searches models using the Civitai Meilisearch endpoint."""
-        meili_url = "https://search.civitai.com/multi-search"
-        headers = {'Content-Type': 'application/json'}
-        headers['Authorization'] = f'Bearer 8c46eb2508e21db1e9828a97968d91ab1ca1caa5f70a00e88a2ba1e286603b61' #Nothing harmful, everyone have the same meilisearch bearer token. I checked with 3 accounts
-
-        offset = max(0, (page - 1) * limit)
-
-        # Map simple sort terms to Meilisearch syntax
-        sort_mapping = {
-            "Relevancy": "id:desc",
-            "Most Downloaded": "metrics.downloadCount:desc",
-            "Highest Rated": "metrics.thumbsUpCount:desc", 
-            "Most Liked": "metrics.favoriteCount:desc", 
-            "Most Discussed": "metrics.commentCount:desc", 
-            "Most Collected": "metrics.collectedCount:desc", 
-            "Most Buzz": "metrics.tippedAmountCount:desc", 
-            "Newest": "createdAt:desc", 
+        if isinstance(result, dict) and {"items", "metadata"}.issubset(result):
+            return result
+        return {
+            "items": [],
+            "metadata": {
+                "totalItems": 0,
+                "currentPage": page,
+                "pageSize": limit,
+                "totalPages": 0,
+            },
         }
-        meili_sort = [sort_mapping.get(sort, "metrics.downloadCount:desc")]
-        
-        
-        # --- Build Filters ---
-        # Meilisearch uses an array of filter groups. Filters within a group are OR'd, groups are AND'd.
-        filter_groups = []
 
-        # Type Filter Group (OR logic)
-        if types and isinstance(types, list) and len(types) > 0:
-             # Map internal type keys/display names to API type names if needed,
-             # but the provided example uses direct type names like "LORA". Let's assume frontend sends correct names.
-             # Ensure proper quoting for string values in the filter.
-             type_filters = [f'"type"="{t}"' for t in types]
-             filter_groups.append(type_filters)
+    def search_models_meili(
+        self,
+        query: str,
+        types: Optional[Iterable[str]] = None,
+        base_models: Optional[Iterable[str]] = None,
+        sort: str = "metrics.downloadCount:desc",
+        limit: int = 20,
+        page: int = 1,
+        nsfw: Optional[bool] = None,
+    ) -> ResponseType:
+        mapped_sort = _MEILI_SORT_MAP.get(sort, sort)
+        query_obj = _MeiliQuery(
+            query=query,
+            types=types,
+            base_models=base_models,
+            sort=mapped_sort,
+            limit=limit,
+            page=page,
+            nsfw=nsfw,
+        )
+        payload = query_obj.payload()
+        result = self._send(
+            "POST",
+            self.MEILI_URL,
+            json_data=payload,
+            headers={"Authorization": _MEILI_TOKEN},
+            timeout=25,
+        )
+        if isinstance(result, dict) and "error" in result:
+            return result
+        if not isinstance(result, dict) or "results" not in result:
+            return {"hits": [], "limit": query_obj.limit, "offset": query_obj.offset, "estimatedTotalHits": 0}
 
-        # Base Model Filter Group (OR logic)
-        if base_models and isinstance(base_models, list) and len(base_models) > 0:
-            base_model_filters = [f'"version.baseModel"="{bm}"' for bm in base_models]
-            filter_groups.append(base_model_filters)
-
-        # NSFW Filter (applied as AND) - Meili typically uses boolean facets or numeric levels
-        # Let's filter by 'nsfwLevel' being acceptable (1=None, 2=Mild, 4=Mature) if NSFW is false or None.
-        # If NSFW is true, we don't add this filter (allow all levels).
-        # This might need adjustment based on exact Meili setup and desired behavior.
-        # An alternative is filtering on the 'nsfw' boolean field if it exists directly.
-        if nsfw is None or nsfw is False:
-             # Example: Allow levels 1, 2, 4 (adjust as needed)
-             # Meili syntax for multiple values: nsfwLevel IN [1, 2, 4]
-             filter_groups.append("nsfwLevel IN [1, 2, 4]") # Filter applied directly as AND
-             # Or maybe filter on the boolean `nsfw` field if it's indexed:
-             # filter_groups.append("nsfw = false")
-
-        # Availability Filter (Public)
-        filter_groups.append("availability = Public") # Filter applied directly as AND
-
-        # --- Construct Request Body ---
-        payload = {
-            "queries": [
-                {
-                    "q": query if query else "", # Send empty string "" if no query
-                    "indexUid": "models_v9",
-                    "facets": [ # Keep facets requested by frontend if needed for analytics/refinement UI
-                        "category.name",
-                        "checkpointType",
-                        "fileFormats",
-                        "lastVersionAtUnix",
-                        "tags.name",
-                        "type",
-                        "user.username",
-                        "version.baseModel",
-                        "nsfwLevel"
-                    ],
-                    "attributesToHighlight": [], # Keep empty if not using highlighting
-                    "highlightPreTag": "__ais-highlight__",
-                    "highlightPostTag": "__/ais-highlight__",
-                    "limit": max(1, min(100, limit)), # Ensure reasonable limit
-                    "offset": offset,
-                    "filter": filter_groups
-                }
-            ]
-        }
-        if(sort != "Relevancy"):
-            payload["queries"][0]["sort"] = meili_sort
-        
-
-        try:
-            # print(f"DEBUG: Meili Search Payload: {json.dumps(payload, indent=2)}") # Debugging payload
-            response = requests.post(meili_url, headers=headers, json=payload, timeout=25) # Use reasonable timeout
-            response.raise_for_status()
-
-            results_data = response.json()
-            # print(f"DEBUG: Meili Search Response: {json.dumps(results_data, indent=2)}") # Debugging response
-
-            # Basic validation of response structure
-            if not results_data or not isinstance(results_data.get('results'), list) or not results_data['results']:
-                 print(f"Warning: Meili search returned unexpected structure or empty results list: {results_data}")
-                 # Return empty structure consistent with expected format downstream
-                 return {"hits": [], "limit": limit, "offset": offset, "estimatedTotalHits": 0}
-
-            # Return the content of the first result (assuming single query)
-            first_result = results_data['results'][0]
-            if isinstance(first_result, dict) and "hits" in first_result:
-                 # Return the relevant part of the response
-                 return first_result # Includes hits, processingTimeMs, limit, offset, estimatedTotalHits etc.
-            else:
-                  print(f"Warning: Meili search first result structure invalid: {first_result}")
-                  return {"hits": [], "limit": limit, "offset": offset, "estimatedTotalHits": 0}
-
-        except requests.exceptions.HTTPError as http_err:
-            error_detail = None
-            status_code = http_err.response.status_code
-            try:
-                error_detail = http_err.response.json()
-            except json.JSONDecodeError:
-                error_detail = http_err.response.text[:200]
-            print(f"Civitai Meili Search HTTP Error ({meili_url}): Status {status_code}, Response: {error_detail}")
-            return {"error": f"Meili HTTP Error: {status_code}", "details": error_detail, "status_code": status_code}
-
-        except requests.exceptions.RequestException as req_err:
-            print(f"Civitai Meili Search Request Error ({meili_url}): {req_err}")
-            return {"error": str(req_err), "details": None, "status_code": None}
-
-        except json.JSONDecodeError as json_err:
-            print(f"Civitai Meili Search Error: Failed to decode JSON response from {meili_url}: {json_err}")
-            response_text = response.text[:200] if hasattr(response, 'text') else "N/A"
-            return {"error": "Invalid JSON response from Meili", "details": response_text, "status_code": response.status_code if hasattr(response, 'status_code') else None}
+        first = result.get("results")
+        if isinstance(first, list) and first:
+            first_entry = first[0]
+            if isinstance(first_entry, dict) and "hits" in first_entry:
+                return first_entry
+        return {"hits": [], "limit": query_obj.limit, "offset": query_obj.offset, "estimatedTotalHits": 0}

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,289 +1,204 @@
-# ================================================
-# File: utils/helpers.py
-# ================================================
+"""Helper utilities for directory handling, URL parsing, and file selection."""
+from __future__ import annotations
+
 import os
-import urllib.parse
-import re 
+import re
+from contextlib import suppress
+from functools import lru_cache
 from pathlib import Path
-from typing import Optional, List, Dict, Any
+from typing import Any, Dict, Iterable, List, Optional
+from urllib.parse import parse_qs, urlparse
 
-import folder_paths 
+import folder_paths
 
-# Import config values needed here
-from ..config import PLUGIN_ROOT, MODEL_TYPE_DIRS
+from ..config import MODEL_TYPE_DIRS
 
+_CIVITAI_HOSTS = {"civitai.com", "www.civitai.com"}
+_MAX_FILENAME_LEN = 200
+_RESERVED_NAMES = {
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    "COM1",
+    "COM2",
+    "COM3",
+    "COM4",
+    "COM5",
+    "COM6",
+    "COM7",
+    "COM8",
+    "COM9",
+    "LPT1",
+    "LPT2",
+    "LPT3",
+    "LPT4",
+    "LPT5",
+    "LPT6",
+    "LPT7",
+    "LPT8",
+    "LPT9",
+}
+_INVALID_TRANSLATION = str.maketrans({c: "_" for c in '<>:"/\\|?*' + "".join(map(chr, range(32)))})
+
+
+def _models_root() -> Path:
+    models_dir = getattr(folder_paths, "models_dir", None)
+    if models_dir:
+        return Path(models_dir)
+    base = getattr(folder_paths, "base_path", os.getcwd())
+    return Path(base) / "models"
+
+
+def _resolve_registered_dir(folder_type: str) -> Path:
+    with suppress(Exception):
+        directory = folder_paths.get_directory_by_type(folder_type)
+        if directory:
+            return Path(directory)
+    with suppress(Exception):
+        get_fp = getattr(folder_paths, "get_folder_paths", None)
+        if callable(get_fp):
+            candidates = get_fp(folder_type)
+            if isinstance(candidates, (list, tuple)):
+                for candidate in candidates:
+                    if candidate:
+                        return Path(candidate)
+    return _models_root() / folder_type
+
+
+@lru_cache(maxsize=None)
 def get_model_dir(model_type: str) -> str:
-    """
-    Resolve the absolute directory path for a model type using ComfyUI's
-    folder_paths manager. Respects extra_model_paths.yaml and symlinks.
-    Ensures the directory exists.
-    """
-    model_type_raw = (model_type or "").strip()
-    model_type_key = model_type_raw.lower()
+    """Resolve and ensure the directory for a given model type exists."""
+    raw = (model_type or "").strip()
+    key = raw.lower()
+    folder_type = MODEL_TYPE_DIRS.get(key, (None, None))[1]
 
-    display_and_type = MODEL_TYPE_DIRS.get(model_type_key)
-    folder_paths_type = None
-    if display_and_type:
-        _, folder_paths_type = display_and_type
-
-    if display_and_type and folder_paths_type:
-        try:
-            # Preferred: ask ComfyUI for the configured directory for this type
-            full_path = folder_paths.get_directory_by_type(folder_paths_type)
-            # If API returned a falsy value, try alternative lookups
-            if not full_path:
-                raise RuntimeError(f"No directory registered for type '{folder_paths_type}'")
-        except Exception:
-            # Fallback: assume a subdirectory under models_dir
-            print(f"Warning: Could not resolve path for type '{folder_paths_type}' via folder_paths. Falling back to models_dir.")
-            # Try get_folder_paths first
-            full_path = None
-            try:
-                get_fp = getattr(folder_paths, 'get_folder_paths', None)
-                if callable(get_fp):
-                    paths_list = get_fp(folder_paths_type)
-                    if isinstance(paths_list, (list, tuple)) and paths_list:
-                        full_path = paths_list[0]
-            except Exception:
-                pass
-            if not full_path:
-                models_dir = getattr(folder_paths, 'models_dir', None)
-                if not models_dir:
-                    # Last resort: try to infer a models dir near base_path
-                    base = getattr(folder_paths, 'base_path', os.getcwd())
-                    models_dir = os.path.join(base, 'models')
-                full_path = os.path.join(models_dir, folder_paths_type)
+    if folder_type:
+        target = _resolve_registered_dir(folder_type)
     else:
-        # Treat model_type as a literal folder under the main models directory
-        models_dir = getattr(folder_paths, 'models_dir', None)
-        if not models_dir:
-            base = getattr(folder_paths, 'base_path', os.getcwd())
-            models_dir = os.path.join(base, 'models')
-        # Use the raw (case-preserving) folder name
-        full_path = os.path.join(models_dir, model_type_raw)
+        target = _models_root() / (raw or "other")
 
-    # Ensure the directory exists
+    target.mkdir(parents=True, exist_ok=True)
+    return str(target)
+
+
+def _first_int(values: Optional[Iterable[Any]]) -> Optional[int]:
+    for value in values or ():
+        text = str(value).strip()
+        if text.isdigit():
+            return int(text)
+        with suppress(ValueError, TypeError):
+            return int(text)
+    return None
+
+
+def _extract_path_id(parts: List[str], token: str) -> Optional[int]:
+    with suppress(ValueError, IndexError):
+        idx = parts.index(token)
+        candidate = parts[idx + 1]
+        if candidate.isdigit():
+            return int(candidate)
+    return None
+
+
+def parse_civitai_input(url_or_id: str) -> tuple[Optional[int], Optional[int]]:
+    """Parse a Civitai URL or ID string into (model_id, version_id)."""
+    value = (url_or_id or "").strip()
+    if not value:
+        return None, None
+    if value.isdigit():
+        return int(value), None
+
+    candidate = value
+    if "//" not in candidate:
+        candidate = f"https://civitai.com/{candidate.lstrip('/')}"
+
     try:
-        # Ensure full_path is a string path
-        if not isinstance(full_path, (str, bytes, os.PathLike)):
-            raise TypeError(f"Resolved directory for '{model_type_key}' is invalid: {full_path!r}")
-        os.makedirs(full_path, exist_ok=True)
-    except Exception as e:
-        print(f"Error: Could not create directory '{full_path}': {e}")
-
-    return full_path
-
-def parse_civitai_input(url_or_id: str) -> tuple[int | None, int | None]:
-    """
-    Parses Civitai URL or ID string.
-    Returns: (model_id, version_id) tuple. Both can be None.
-    Handles URLs like /models/123 and /models/123?modelVersionId=456
-    """
-    if not url_or_id:
+        parsed = urlparse(candidate)
+    except Exception:
         return None, None
 
-    url_or_id = str(url_or_id).strip()
-    model_id: int | None = None
-    version_id: int | None = None
-    query_params = {}
-
-    # Check if it's just a number (could be model or version ID)
-    # Treat digits-only input as MODEL ID primarily, as users often copy just that.
-    # Version ID can be specified separately or via full URL query param.
-    if url_or_id.isdigit():
-        try:
-            # Assume it's a Model ID if just digits are provided.
-             model_id = int(url_or_id)
-             print(f"Parsed input '{url_or_id}' as Model ID.")
-             # Don't assume it's a version ID here. Let it be specified if needed.
-             return model_id, None
-        except (ValueError, TypeError):
-              print(f"Warning: Could not parse '{url_or_id}' as a numeric ID.")
-              return None, None
-
-    # If not just digits, try parsing as URL
-    try:
-        parsed_url = urllib.parse.urlparse(url_or_id)
-
-        # Basic check for URL structure and domain
-        if not parsed_url.scheme or not parsed_url.netloc:
-            # Maybe it's a path like /models/123 without the domain?
-            if url_or_id.startswith(("/models/", "/model-versions/")):
-                 # Re-parse with a dummy scheme and domain
-                 parsed_url = urllib.parse.urlparse("https://civitai.com" + url_or_id)
-                 if not parsed_url.path: # If still fails, give up
-                      print(f"Input '{url_or_id}' is not a recognizable Civitai path or URL.")
-                      return None, None
-            else:
-                 print(f"Input '{url_or_id}' is not a valid ID or Civitai URL/path.")
-                 return None, None
-
-        # Check domain if it was present
-        if parsed_url.netloc and "civitai.com" not in parsed_url.netloc.lower():
-            print(f"Input URL '{url_or_id}' is not a Civitai URL.")
-            return None, None
-
-        # Extract path components and query parameters
-        path_parts = [p for p in parsed_url.path.split('/') if p] # Remove empty parts
-        query_params = urllib.parse.parse_qs(parsed_url.query)
-
-        # --- Logic ---
-        # 1. Check query params for modelVersionId FIRST (most explicit)
-        if 'modelVersionId' in query_params:
-            try:
-                version_id = int(query_params['modelVersionId'][0])
-                print(f"Found Version ID {version_id} in query parameters.")
-            except (ValueError, IndexError, TypeError):
-                print(f"Warning: Found modelVersionId in query but couldn't parse: {query_params.get('modelVersionId')}")
-                version_id = None # Reset if parsing failed
-
-        # 2. Check path for /models/ID
-        model_id_from_path = None
-        if "models" in path_parts:
-             try:
-                 models_index = path_parts.index("models")
-                 if models_index + 1 < len(path_parts):
-                     # Take the part right after /models/ and check if it's digits
-                     potential_id_str = path_parts[models_index + 1]
-                     if potential_id_str.isdigit():
-                          model_id_from_path = int(potential_id_str)
-                          print(f"Found Model ID {model_id_from_path} in URL path.")
-             except (ValueError, IndexError, TypeError):
-                  print(f"Warning: Found /models/ in path but couldn't parse ID from {path_parts}")
-
-        # 3. Check path for /model-versions/ID (less common, usually doesn't contain model ID)
-        version_id_from_path = None
-        if version_id is None and "model-versions" in path_parts: # Only check if not found in query
-             try:
-                 versions_index = path_parts.index("model-versions")
-                 if versions_index + 1 < len(path_parts):
-                     potential_id_str = path_parts[versions_index + 1]
-                     if potential_id_str.isdigit():
-                           version_id_from_path = int(potential_id_str)
-                           # Set version_id only if not already set by query param
-                           if version_id is None:
-                                version_id = version_id_from_path
-                                print(f"Found Version ID {version_id} in URL path.")
-             except (ValueError, IndexError, TypeError):
-                  print(f"Warning: Found /model-versions/ in path but couldn't parse ID from {path_parts}")
-
-        # 4. Assign final model ID (prefer path over digits-only assumption if URL was parsed)
-        if model_id_from_path is not None:
-             model_id = model_id_from_path
-        # If no model ID found yet and input looked like a URL, maybe it was ONLY a version URL?
-        elif model_id is None and version_id is not None:
-            print("Warning: Found Version ID but no Model ID in the URL. Model info might be incomplete.")
-         # Keep the initially parsed model_id if input was digits-only
-
-    except Exception as e:
-        print(f"Error parsing Civitai input '{url_or_id}': {e}")
+    host = parsed.netloc.split(":")[0].lower()
+    if host and host not in _CIVITAI_HOSTS:
         return None, None
 
-    print(f"Parsed Civitai input: Model ID = {model_id}, Version ID = {version_id}")
-    # Return the determined IDs. It's the caller's responsibility to fetch model info if only version ID is present.
+    parts = [p for p in parsed.path.split("/") if p]
+    query = parse_qs(parsed.query)
+
+    model_id = _extract_path_id(parts, "models")
+    version_id = _first_int(query.get("modelVersionId")) or _extract_path_id(parts, "model-versions")
+
     return model_id, version_id
 
-# Updated sanitize_filename to be more restrictive
+
 def sanitize_filename(filename: str, default_filename: str = "downloaded_model") -> str:
-    """
-    Stricter filename sanitization. Replaces invalid characters, trims whitespace,
-    handles reserved names (Windows), and ensures it's not empty.
-    Aims for better cross-OS compatibility.
-    """
+    """Return a filesystem-safe filename across platforms."""
     if not filename:
         return default_filename
-
-    # Decode if bytes
     if isinstance(filename, bytes):
-        try:
-            filename = filename.decode('utf-8')
-        except UnicodeDecodeError:
-            # If decode fails, fall back to a safe default representation or hex
-            # For simplicity, just use default for now if decoding problematic bytes
-            return default_filename + "_decode_error"
+        filename = filename.decode("utf-8", errors="ignore") or default_filename
 
-    # Remove characters invalid for Windows/Linux/MacOS filenames
-    # Invalid Chars: < > : " / \ | ? * and control characters (0-31)
-    # Also replace NULL character just in case.
-    sanitized = re.sub(r'[\x00-\x1f<>:"/\\|?*]', '_', filename)
+    sanitized = filename.translate(_INVALID_TRANSLATION)
+    sanitized = re.sub(r"\s+", "_", sanitized)
+    sanitized = re.sub(r"_+", "_", sanitized).strip("._ ")
 
-    # Replace sequences of multiple underscores or spaces introduced by replacement
-    sanitized = re.sub(r'[_ ]{2,}', '_', sanitized)
-
-    # Remove leading/trailing whitespace, dots, underscores
-    sanitized = sanitized.strip('. _')
-
-    # Windows Reserved Names (case-insensitive)
-    reserved_names = {'CON', 'PRN', 'AUX', 'NUL', 'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9', 'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9'}
-     # Check base name without extension
-    base_name, ext = os.path.splitext(sanitized)
-    if base_name.upper() in reserved_names:
-         sanitized = f"_{base_name}_{ext}" # Prepend underscore
-
-    # Prevent names that are just '.' or '..' (though stripping dots should handle this)
-    if sanitized == '.' or sanitized == '..':
-        sanitized = default_filename + "_invalid_name"
-
-     # If sanitization results in an empty string (unlikely now), use default
-    if not sanitized:
+    if not sanitized or sanitized in {".", ".."}:
         sanitized = default_filename
 
-    # Optional: Limit overall length (e.g., 200 chars), considering path limits
-    # Be careful as some systems have path limits, not just filename limits
-    max_len = 200 # A reasonable limit for the filename itself
-    if len(sanitized) > max_len:
-         name_part, ext_part = os.path.splitext(sanitized)
-         # Truncate the name part, ensuring total length is within max_len
-         allowed_name_len = max_len - len(ext_part)
-         if allowed_name_len <= 0: # Handle case where extension itself is too long
-              sanitized = sanitized[:max_len] # Truncate forcefully
-         else:
-              sanitized = name_part[:allowed_name_len] + ext_part
-         print(f"Warning: Sanitized filename truncated to {max_len} characters.")
+    stem, ext = os.path.splitext(sanitized)
+    if stem.upper() in _RESERVED_NAMES:
+        sanitized = f"_{stem}{ext}"
 
-    return sanitized
-    
+    if len(sanitized) > _MAX_FILENAME_LEN:
+        allowed = _MAX_FILENAME_LEN - len(ext)
+        if allowed <= 0:
+            sanitized = sanitized[:_MAX_FILENAME_LEN]
+        else:
+            sanitized = stem[:allowed] + ext
+
+    return sanitized or default_filename
+
+
 def select_primary_file(files: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
-    """
-    Selects the best file from a list of files based on a heuristic.
-    Prefers primary, then safetensors, then pruned, etc.
-    Returns the selected file dictionary or None.
-    """
-    if not files or not isinstance(files, list):
+    """Select the most appropriate file using a simple heuristic."""
+    if not files:
         return None
-
-    # First, try to find a file explicitly marked as "primary" with a valid download URL
-    primary_marked_file = next((f for f in files if isinstance(f, dict) and f.get("primary") and f.get('downloadUrl')), None)
-    if primary_marked_file:
-        return primary_marked_file
-
-    # If no primary file is marked, sort all available files using a heuristic
-    def sort_key(file_obj):
-        if not isinstance(file_obj, dict): return 99
-        if not file_obj.get('downloadUrl'): return 98 # Deprioritize files without URL
-
-        name_lower = file_obj.get("name", "").lower()
-        meta = file_obj.get("metadata", {}) or {}
-        format_type = meta.get("format", "").lower()
-        size_type = meta.get("size", "").lower()
-        
-        # Fallback to file extension if format metadata missing
-        is_safetensor = ".safetensors" in name_lower or format_type == "safetensor"
-        is_pickle = ".ckpt" in name_lower or ".pt" in name_lower or format_type == "pickletensor"
-        is_pruned = size_type == "pruned"
-
-        if is_safetensor and is_pruned: return 0
-        if is_safetensor: return 1
-        if is_pickle and is_pruned: return 2
-        if is_pickle: return 3
-        # Prioritize model files over others like VAEs if type is available
-        if file_obj.get("type") == "Model": return 4
-        if file_obj.get("type") == "Pruned Model": return 5
-        return 10 # Other types last
 
     valid_files = [f for f in files if isinstance(f, dict) and f.get("downloadUrl")]
     if not valid_files:
         return None
-        
-    sorted_files = sorted(valid_files, key=sort_key)
-    return sorted_files[0]
+
+    def priority(file_obj: Dict[str, Any]) -> tuple:
+        meta = file_obj.get("metadata") or {}
+        name = (file_obj.get("name") or "").lower()
+        fmt = (meta.get("format") or "").lower()
+        size_tag = (meta.get("size") or "").lower()
+        file_type = (file_obj.get("type") or "").lower()
+
+        safetensor = "safetensor" in fmt or name.endswith(".safetensors")
+        pickle = any(name.endswith(ext) for ext in (".ckpt", ".pt")) or "pickle" in fmt
+        pruned = size_tag == "pruned"
+
+        format_rank = (
+            0
+            if safetensor and pruned
+            else 1
+            if safetensor
+            else 2
+            if pickle and pruned
+            else 3
+            if pickle
+            else 4
+            if file_type == "model"
+            else 5
+            if file_type == "pruned model"
+            else 6
+        )
+
+        return (
+            0 if file_obj.get("primary") else 1,
+            format_rank,
+            name,
+        )
+
+    return min(valid_files, key=priority)


### PR DESCRIPTION
## Summary
- streamline the Civitai API wrapper with shared request handling and Meilisearch payload helpers
- simplify helper utilities for resolving model directories, parsing inputs, and selecting files
- tighten filename sanitisation and iterable handling while removing redundant logging

## Testing
- python -m compileall api utils

------
https://chatgpt.com/codex/tasks/task_e_68ca89beeda08325885a6ca69a9d8db4