### PR TITLE
Merge search cards with inline download drawer

### DIFF
--- a/web/js/api/civitai.js
+++ b/web/js/api/civitai.js
@@ -49,6 +49,27 @@ export class CivitaiDownloaderAPI {
     });
   }
 
+  static async queueDownload(payload) {
+    // Alias of downloadModel to keep terminology aligned with queue-based UI.
+    return await this.downloadModel(payload);
+  }
+
+  static async queueDownloads(items = []) {
+    const results = [];
+    for (const item of items) {
+      try {
+        const res = await this.queueDownload(item);
+        results.push(res);
+      } catch (error) {
+        results.push({
+          error: error?.details || error?.message || "queueDownload failed",
+          item,
+        });
+      }
+    }
+    return results;
+  }
+
   static async getModelDetails(params) {
     return await this._request("/civitai/get_model_details", {
       method: "POST",

--- a/web/js/civitaiDownloader.css
+++ b/web/js/civitaiDownloader.css
@@ -729,3 +729,171 @@
     right: 5px;
     /* ... */
 }
+
+/* Card + drawer styles for merged UI */
+.civi-card {
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    padding: 10px;
+    margin: 8px;
+    border-radius: 8px;
+    background: var(--civi-card-bg, rgba(0, 0, 0, 0.35));
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    transition: box-shadow 160ms ease;
+}
+.civi-card:hover {
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
+}
+
+.civi-card .civi-card-top {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+}
+.civi-thumb img {
+    width: 96px;
+    height: 96px;
+    object-fit: cover;
+    border-radius: 6px;
+}
+.civi-meta {
+    flex: 1;
+    min-width: 0;
+}
+.civi-title {
+    margin: 0 0 4px 0;
+    font-size: 1rem;
+}
+.civi-actions {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.civi-version-select {
+    min-width: 160px;
+}
+.civi-btn {
+    padding: 6px 10px;
+    border-radius: 6px;
+    background: var(--civi-btn-bg, #2b6);
+    border: none;
+    cursor: pointer;
+}
+.civi-btn-quick-download {
+    background: var(--civi-primary, #1976d2);
+    color: #fff;
+}
+
+.civi-local-meta {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    font-size: 0.85rem;
+    color: #cfd8dc;
+}
+.civi-local-path {
+    max-width: 60%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    cursor: pointer;
+}
+.civi-triggers {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.civi-trigger-pill {
+    background: rgba(255, 255, 255, 0.06);
+    border: none;
+    padding: 3px 8px;
+    border-radius: 12px;
+    cursor: pointer;
+    color: inherit;
+}
+
+.civi-download-drawer {
+    border-top: 1px dashed rgba(255, 255, 255, 0.1);
+    padding-top: 10px;
+    margin-top: 8px;
+}
+.civi-download-drawer.hidden {
+    display: none;
+}
+.civi-drawer-inner {
+    display: grid;
+    grid-template-columns: minmax(220px, 1fr) 260px;
+    gap: 12px;
+    align-items: start;
+}
+.civi-files-list {
+    max-height: 180px;
+    overflow: auto;
+    padding: 4px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+.civi-file-row {
+    font-size: 0.85rem;
+}
+.civi-file-unavailable {
+    opacity: 0.6;
+    margin-left: 6px;
+}
+.civi-drawer-actions {
+    grid-column: 1 / -1;
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+}
+
+.civi-progress {
+    height: 22px;
+    border-radius: 6px;
+    background: linear-gradient(90deg, rgba(0, 150, 136, 0.36) var(--civi-progress, 0%), rgba(255, 255, 255, 0.04) var(--civi-progress, 0%));
+    color: #fff;
+    padding: 4px 8px;
+    font-size: 0.85rem;
+    min-width: 140px;
+}
+.civi-progress.failed {
+    background: linear-gradient(90deg, rgba(198, 40, 40, 0.55) var(--civi-progress, 0%), rgba(255, 255, 255, 0.04) var(--civi-progress, 0%));
+}
+
+.civi-queued-badge {
+    display: inline-block;
+    background: rgba(0, 0, 0, 0.45);
+    padding: 4px 8px;
+    border-radius: 10px;
+    margin-left: 8px;
+    font-size: 0.8rem;
+    color: #fff;
+}
+
+.civi-preview-title {
+    font-weight: 600;
+    margin-bottom: 4px;
+}
+.civi-preview-meta {
+    font-size: 0.85rem;
+    opacity: 0.8;
+    margin-bottom: 6px;
+}
+.civi-preview-desc {
+    font-size: 0.85rem;
+    line-height: 1.4;
+}
+.civi-preview-desc.subtle {
+    opacity: 0.7;
+    margin-top: 6px;
+}
+
+.civi-card.drawer-open {
+    border-color: rgba(21, 101, 192, 0.55);
+    box-shadow: 0 0 0 1px rgba(21, 101, 192, 0.35);
+}

--- a/web/js/ui/handlers/eventListeners.js
+++ b/web/js/ui/handlers/eventListeners.js
@@ -153,6 +153,9 @@ export function setupEventListeners(ui) {
 
     // Search results actions, including click-to-toggle blur
     ui.searchResultsContainer.addEventListener('click', (event) => {
+        if (ui.settings?.mergedSearchDownloadUI) {
+            return;
+        }
         const thumbContainer = event.target.closest('.civitai-thumbnail-container');
         if (thumbContainer) {
             const nsfwLevel = Number(thumbContainer.dataset.nsfwLevel ?? thumbContainer.getAttribute('data-nsfw-level'));

--- a/web/js/ui/handlers/searchHandler.js
+++ b/web/js/ui/handlers/searchHandler.js
@@ -1,39 +1,365 @@
-import { CivitaiDownloaderAPI } from "../../api/civitai.js";
+import { toggleDrawer, populateDrawerWithDetails, renderLocalInfo } from '../searchRenderer.js';
+import { CivitaiDownloaderAPI } from '../../api/civitai.js';
+
+const POLL_INTERVAL = 3000;
 
 export async function handleSearchSubmit(ui) {
-    ui.searchSubmitButton.disabled = true;
-    ui.searchSubmitButton.textContent = 'Searching...';
-    ui.searchResultsContainer.innerHTML = '<p><i class="fas fa-spinner fa-spin"></i> Searching...</p>';
-    ui.searchPaginationContainer.innerHTML = '';
-    ui.ensureFontAwesome();
+  ui.searchSubmitButton.disabled = true;
+  ui.searchSubmitButton.textContent = 'Searching...';
+  ui.searchResultsContainer.innerHTML = '<p><i class="fas fa-spinner fa-spin"></i> Searching...</p>';
+  ui.searchPaginationContainer.innerHTML = '';
+  ui.ensureFontAwesome();
 
-    const params = {
-        query: ui.searchQueryInput.value.trim(),
-        model_types: ui.searchTypeSelect.value === 'any' ? [] : [ui.searchTypeSelect.value],
-        base_models: ui.searchBaseModelSelect.value === 'any' ? [] : [ui.searchBaseModelSelect.value],
-        sort: ui.searchSortSelect.value,
-        limit: ui.searchPagination.limit,
-        page: ui.searchPagination.currentPage,
-        api_key: ui.settings.apiKey,
-    };
+  const params = {
+    query: ui.searchQueryInput.value.trim(),
+    model_types: ui.searchTypeSelect.value === 'any' ? [] : [ui.searchTypeSelect.value],
+    base_models: ui.searchBaseModelSelect.value === 'any' ? [] : [ui.searchBaseModelSelect.value],
+    sort: ui.searchSortSelect.value,
+    limit: ui.searchPagination.limit,
+    page: ui.searchPagination.currentPage,
+    api_key: ui.settings.apiKey,
+  };
 
-    try {
-        const response = await CivitaiDownloaderAPI.searchModels(params);
-        if (!response || !response.metadata || !Array.isArray(response.items)) {
-            console.error("Invalid search response structure:", response);
-            throw new Error("Received invalid data from search API.");
-        }
-
-        ui.renderSearchResults(response.items);
-        ui.renderSearchPagination(response.metadata);
-
-    } catch (error) {
-        const message = `Search failed: ${error.details || error.message || 'Unknown error'}`;
-        console.error("Search Submit Error:", error);
-        ui.searchResultsContainer.innerHTML = `<p style="color: var(--error-text, #ff6b6b);">${message}</p>`;
-        ui.showToast(message, 'error');
-    } finally {
-        ui.searchSubmitButton.disabled = false;
-        ui.searchSubmitButton.textContent = 'Search';
+  try {
+    const response = await CivitaiDownloaderAPI.searchModels(params);
+    if (!response || !response.metadata || !Array.isArray(response.items)) {
+      console.error('Invalid search response structure:', response);
+      throw new Error('Received invalid data from search API.');
     }
+
+    ui.renderSearchResults(response.items);
+    ui.renderSearchPagination(response.metadata);
+  } catch (error) {
+    const message = `Search failed: ${error.details || error.message || 'Unknown error'}`;
+    console.error('Search Submit Error:', error);
+    ui.searchResultsContainer.innerHTML = `<p style="color: var(--error-text, #ff6b6b);">${message}</p>`;
+    ui.showToast(message, 'error');
+  } finally {
+    ui.searchSubmitButton.disabled = false;
+    ui.searchSubmitButton.textContent = 'Search';
+  }
+}
+
+export function initSearchHandlers(containerEl, options = {}) {
+  if (!containerEl || containerEl.__civiHandlersAttached) return;
+  containerEl.__civiHandlersAttached = true;
+
+  const api = options.api || CivitaiDownloaderAPI;
+  const toast = options.toast || ((msg, type) => {
+    if (type === 'error') console.error(msg);
+    else console.log(msg);
+  });
+  const getSettings = options.getSettings || (() => options.settings || {});
+  const getModelTypeOptions = options.getModelTypeOptions || (() => []);
+  const inferModelType = options.inferModelType || (() => null);
+
+  containerEl.addEventListener('click', async (event) => {
+    const card = event.target.closest('.civi-card');
+    if (!card) return;
+
+    if (event.target.closest('.civi-btn-quick-download')) {
+      event.preventDefault();
+      await handleQuickDownload(card, { api, toast, getSettings, getModelTypeOptions, inferModelType, options });
+      return;
+    }
+
+    if (event.target.closest('.civi-btn-details')) {
+      event.preventDefault();
+      await handleDetails(card, { api, toast, getSettings, options });
+      return;
+    }
+
+    if (event.target.closest('.civi-btn-close')) {
+      event.preventDefault();
+      toggleDrawer(card, false);
+      return;
+    }
+
+    if (event.target.closest('.civi-trigger-pill')) {
+      const text = event.target.textContent || '';
+      try {
+        await navigator.clipboard.writeText(text);
+        toast(`${text} copied`, 'success');
+      } catch (err) {
+        toast('Failed to copy trigger', 'error');
+      }
+      return;
+    }
+
+    if (event.target.closest('.civi-local-path')) {
+      event.preventDefault();
+      const path = event.target.textContent;
+      if (!path || path === 'Not downloaded') return;
+      if (typeof options.onOpenLocalPath === 'function') {
+        options.onOpenLocalPath(path, card);
+      } else {
+        toast('Open path not supported in this build', 'info');
+      }
+      return;
+    }
+  });
+
+  containerEl.addEventListener('click', async (event) => {
+    const queueBtn = event.target.closest('.civi-btn-queue');
+    if (!queueBtn) return;
+    event.preventDefault();
+    const card = event.target.closest('.civi-card');
+    if (!card) return;
+    await handleQueue(card, { api, toast, getSettings, options });
+  });
+}
+
+async function handleQuickDownload(card, ctx) {
+  try {
+    toggleDrawer(card, true);
+    const modelId = card.dataset.modelId;
+    const versionSelect = card.querySelector('.civi-version-select');
+    const versionId = versionSelect ? versionSelect.value : card.dataset.versionId;
+    const settings = ctx.getSettings();
+    const payload = {
+      model_url_or_id: modelId,
+      model_version_id: versionId ? Number(versionId) : null,
+      api_key: settings?.apiKey || '',
+    };
+    const details = await ctx.api.getModelDetails(payload);
+    if (!details || details.success === false) {
+      const message = details?.details || details?.error || 'Failed to load model details';
+      ctx.toast(message, 'error');
+      return;
+    }
+
+    const modelTypeOptions = ctx.getModelTypeOptions();
+    const inferred = ctx.inferModelType(details.model_type || card.dataset.modelType);
+    const defaults = {
+      modelType: inferred || settings?.defaultModelType || card.dataset.modelType || '',
+      subdir: '',
+      filename: '',
+    };
+    if (defaults.modelType) card.dataset.modelType = defaults.modelType;
+    if (details.version_id) card.dataset.versionId = details.version_id;
+    populateDrawerWithDetails(card, details, modelTypeOptions, defaults);
+    if (versionSelect && details.version_id) {
+      versionSelect.value = String(details.version_id);
+    }
+
+    if (typeof ctx.options.onDetailsLoaded === 'function') {
+      ctx.options.onDetailsLoaded(card, details);
+    }
+
+    if (ctx.options.getLocalInfo) {
+      try {
+        const info = await ctx.options.getLocalInfo({
+          modelId,
+          versionId: details.version_id || versionId,
+        });
+        renderLocalInfo(card, info);
+      } catch (err) {
+        // ignore missing endpoint
+      }
+    }
+  } catch (error) {
+    console.error('Quick download error', error);
+    ctx.toast('Failed to load download options', 'error');
+  }
+}
+
+async function handleDetails(card, ctx) {
+  try {
+    const modelId = card.dataset.modelId;
+    const versionSelect = card.querySelector('.civi-version-select');
+    const versionId = versionSelect ? versionSelect.value : card.dataset.versionId;
+    const settings = ctx.getSettings();
+    const payload = {
+      model_url_or_id: modelId,
+      model_version_id: versionId ? Number(versionId) : null,
+      api_key: settings?.apiKey || '',
+    };
+    const details = await ctx.api.getModelDetails(payload);
+    if (!details || details.success === false) {
+      const message = details?.details || details?.error || 'Failed to load details';
+      ctx.toast(message, 'error');
+      return;
+    }
+    if (typeof ctx.options?.onShowDetails === 'function') {
+      ctx.options.onShowDetails(details, card);
+    } else {
+      ctx.toast('Details loaded. Integrate preview modal to show them.', 'info');
+      console.info('[Civicomfy] Details payload', details);
+    }
+  } catch (error) {
+    console.error('Details error', error);
+    ctx.toast('Failed to open details', 'error');
+  }
+}
+
+async function handleQueue(card, ctx) {
+  try {
+    const settings = ctx.getSettings();
+    if (!settings?.apiKey) {
+      ctx.toast('API key required. Set it in Settings.', 'error');
+      if (typeof ctx.options.onRequireApiKey === 'function') {
+        ctx.options.onRequireApiKey();
+      }
+      return;
+    }
+    const payload = buildPayloadFromDrawer(card, settings);
+    if (!payload) {
+      ctx.toast('Please select a file or version to download.', 'error');
+      return;
+    }
+    const response = await ctx.api.queueDownload(payload);
+    if (response?.status === 'exists' || response?.status === 'exists_size_mismatch') {
+      ctx.toast(response.message || 'Model already downloaded.', 'info');
+      toggleDrawer(card, false);
+      return;
+    }
+    if (!response || response.status !== 'queued') {
+      const message = response?.message || 'Download did not queue';
+      ctx.toast(message, 'error');
+      return;
+    }
+    const queueId = response.download_id || response.queueId;
+    if (!queueId) {
+      ctx.toast('Queue response missing download id', 'error');
+      return;
+    }
+    attachQueueId(card, queueId);
+    ctx.toast('Download queued', 'success');
+    toggleDrawer(card, false);
+    startStatusPolling(card, queueId, ctx);
+    if (typeof ctx.options.onQueueSuccess === 'function') {
+      ctx.options.onQueueSuccess(queueId, response, card);
+    }
+  } catch (error) {
+    console.error('Queue error', error);
+    ctx.toast(error?.details || error?.message || 'Queue failed', 'error');
+  }
+}
+
+function buildPayloadFromDrawer(card, settings) {
+  const modelId = card.dataset.modelId;
+  if (!modelId) return null;
+  const versionSelect = card.querySelector('.civi-version-select');
+  const versionId = versionSelect && versionSelect.value ? Number(versionSelect.value) : undefined;
+  const fileRadio = card.querySelector('.civi-file-radio:checked');
+  const fileId = fileRadio ? Number(fileRadio.value) : undefined;
+  const modelType = card.querySelector('.civi-target-root')?.value || card.dataset.modelType || settings?.defaultModelType || '';
+  const subdir = card.querySelector('.civi-subdir-input')?.value?.trim() || '';
+  const filename = card.querySelector('.civi-filename-input')?.value?.trim() || '';
+  const force = !!card.querySelector('.civi-force-checkbox')?.checked;
+
+  return {
+    model_url_or_id: modelId,
+    model_version_id: Number.isFinite(versionId) ? versionId : undefined,
+    file_id: Number.isFinite(fileId) ? fileId : undefined,
+    model_type: modelType,
+    subdir,
+    custom_filename: filename || undefined,
+    num_connections: settings?.numConnections || 1,
+    force_redownload: force,
+    api_key: settings?.apiKey || '',
+  };
+}
+
+function attachQueueId(card, queueId) {
+  card.dataset.queueId = queueId;
+  let badge = card.querySelector('.civi-queued-badge');
+  if (!badge) {
+    badge = document.createElement('span');
+    badge.className = 'civi-queued-badge';
+    const meta = card.querySelector('.civi-meta');
+    if (meta) meta.appendChild(badge);
+  }
+  badge.textContent = 'Queued';
+}
+
+function startStatusPolling(card, queueId, ctx) {
+  const poll = async () => {
+    try {
+      const status = await ctx.api.getStatus();
+      const entry = findEntryById(status, queueId);
+      if (entry) {
+        renderStatusOnCard(card, entry, ctx);
+        if (['completed', 'failed', 'cancelled'].includes(entry.status)) {
+          finalizeBadge(card, entry.status, ctx);
+          return;
+        }
+      } else if (status && Array.isArray(status.history)) {
+        const historyEntry = status.history.find(item => item.id === queueId);
+        if (historyEntry) {
+          renderStatusOnCard(card, historyEntry, ctx);
+          finalizeBadge(card, historyEntry.status || 'completed', ctx);
+          return;
+        }
+      }
+    } catch (error) {
+      console.error('Status poll error', error);
+    }
+    card.__civiStatusTimer = setTimeout(poll, POLL_INTERVAL);
+  };
+  if (card.__civiStatusTimer) clearTimeout(card.__civiStatusTimer);
+  poll();
+}
+
+function renderStatusOnCard(card, status, ctx) {
+  let bar = card.querySelector('.civi-progress');
+  if (!bar) {
+    bar = document.createElement('div');
+    bar.className = 'civi-progress';
+    const actions = card.querySelector('.civi-actions');
+    (actions || card).appendChild(bar);
+  }
+  const progress = Number.isFinite(status?.progress) ? Math.max(0, Math.min(100, status.progress)) : 0;
+  const speed = Number(status?.speed) > 0 ? `${formatBytes(status.speed)}/s` : '';
+  bar.style.setProperty('--civi-progress', `${progress}%`);
+  bar.textContent = `${Math.round(progress)}%${speed ? ` • ${speed}` : ''}`;
+  if (status?.status === 'failed') {
+    bar.classList.add('failed');
+  }
+}
+
+function finalizeBadge(card, state, ctx) {
+  if (card.__civiStatusTimer) {
+    clearTimeout(card.__civiStatusTimer);
+    card.__civiStatusTimer = null;
+  }
+  const badge = card.querySelector('.civi-queued-badge');
+  if (!badge) return;
+  if (state === 'completed') {
+    badge.textContent = 'Done';
+    ctx.toast('Download finished', 'success');
+  } else if (state === 'failed') {
+    badge.textContent = 'Failed';
+    ctx.toast('Download failed', 'error');
+  } else if (state === 'cancelled') {
+    badge.textContent = 'Cancelled';
+    ctx.toast('Download cancelled', 'info');
+  } else {
+    badge.textContent = state;
+  }
+}
+
+function findEntryById(status, queueId) {
+  if (!status) return null;
+  const lists = ['active', 'queue'];
+  for (const key of lists) {
+    const arr = status[key];
+    if (Array.isArray(arr)) {
+      const found = arr.find(item => item.id === queueId);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+function formatBytes(bytes) {
+  if (!bytes || !Number.isFinite(bytes)) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex++;
+  }
+  return `${Math.round(value * 10) / 10} ${units[unitIndex]}`;
 }

--- a/web/js/ui/handlers/settingsHandler.js
+++ b/web/js/ui/handlers/settingsHandler.js
@@ -11,6 +11,7 @@ export function getDefaultSettings() {
         searchResultLimit: 20,
         hideMatureInSearch: true,
         nsfwBlurMinLevel: 4, // Blur thumbnails with nsfwLevel >= this value
+        mergedSearchDownloadUI: false,
     };
 }
 
@@ -62,6 +63,9 @@ export function applySettings(ui) {
     if (ui.settingsHideMatureCheckbox) {
         ui.settingsHideMatureCheckbox.checked = ui.settings.hideMatureInSearch === true;
     }
+    if (ui.settingsMergedUiCheckbox) {
+        ui.settingsMergedUiCheckbox.checked = ui.settings.mergedSearchDownloadUI === true;
+    }
     if (ui.settingsNsfwThresholdInput) {
         const val = Number(ui.settings.nsfwBlurMinLevel);
         ui.settingsNsfwThresholdInput.value = Number.isFinite(val) ? val : 4;
@@ -73,6 +77,10 @@ export function applySettings(ui) {
         ui.downloadModelTypeSelect.value = ui.settings.defaultModelType || 'checkpoint';
     }
     ui.searchPagination.limit = ui.settings.searchResultLimit || 20;
+
+    if (typeof ui.updateMergedUIState === 'function') {
+        ui.updateMergedUIState();
+    }
 }
 
 export function handleSettingsSave(ui) {
@@ -81,6 +89,7 @@ export function handleSettingsSave(ui) {
     const defaultModelType = ui.settingsDefaultTypeSelect.value;
     const autoOpenStatusTab = ui.settingsAutoOpenCheckbox.checked;
     const hideMatureInSearch = ui.settingsHideMatureCheckbox.checked;
+    const mergedSearchDownloadUI = ui.settingsMergedUiCheckbox?.checked === true;
     const nsfwBlurMinLevel = Number(ui.settingsNsfwThresholdInput.value);
 
     if (isNaN(numConnections) || numConnections < 1 || numConnections > 16) {
@@ -98,6 +107,7 @@ export function handleSettingsSave(ui) {
     ui.settings.autoOpenStatusTab = autoOpenStatusTab;
     ui.settings.hideMatureInSearch = hideMatureInSearch;
     ui.settings.nsfwBlurMinLevel = (Number.isFinite(nsfwBlurMinLevel) && nsfwBlurMinLevel >= 0) ? Math.min(128, Math.round(nsfwBlurMinLevel)) : 4;
+    ui.settings.mergedSearchDownloadUI = mergedSearchDownloadUI;
 
     ui.saveSettingsToCookie();
     ui.applySettings();

--- a/web/js/ui/templates.js
+++ b/web/js/ui/templates.js
@@ -149,6 +149,10 @@ export function modalTemplate(settings = {}) {
                   <input type="checkbox" id="civitai-settings-hide-mature" class="civitai-checkbox" ${settings.hideMatureInSearch ? 'checked' : ''}>
                   <label for="civitai-settings-hide-mature">Hide R-rated (Mature) images in search (click to reveal)</label>
                 </div>
+                <div class="civitai-form-group inline">
+                  <input type="checkbox" id="civitai-settings-merged-ui" class="civitai-checkbox" ${settings.mergedSearchDownloadUI ? 'checked' : ''}>
+                  <label for="civitai-settings-merged-ui">Use merged Search & Download layout (beta)</label>
+                </div>
                 <div class="civitai-form-group">
                   <label for="civitai-settings-nsfw-threshold">NSFW Blur Threshold (nsfwLevel)</label>
                   <input type="number" id="civitai-settings-nsfw-threshold" class="civitai-input" value="${Number.isFinite(settings.nsfwBlurMinLevel) ? settings.nsfwBlurMinLevel : 4}" min="0" max="128" step="1">


### PR DESCRIPTION
## Summary
- replace the search renderer with reusable card + drawer markup that powers the merged search/download view
- wire new search handlers to queue downloads through the existing civitai endpoints, including per-card status polling
- surface queue helpers, feature flag controls, and CSS needed to toggle the merged UI while leaving the classic download tab intact

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68caa02bf778832594cf55b248f259be