### PR TITLE
Replace download tab with library of downloaded models

### DIFF
--- a/server/routes/DeleteLibraryItem.py
+++ b/server/routes/DeleteLibraryItem.py
@@ -1,0 +1,46 @@
+# ================================================
+# File: server/routes/DeleteLibraryItem.py
+# ================================================
+import asyncio
+import json
+from aiohttp import web
+
+import server  # ComfyUI server instance
+from ...downloader.manager import manager as download_manager
+
+prompt_server = server.PromptServer.instance
+
+
+@prompt_server.routes.post("/civitai/library/delete")
+async def route_delete_library_item(request):
+    """Delete a downloaded model from disk and update history."""
+    if not download_manager:
+        return web.json_response({"error": "Download manager not initialized."}, status=500)
+
+    try:
+        data = await request.json()
+    except json.JSONDecodeError:
+        return web.json_response({"error": "Invalid JSON body."}, status=400)
+
+    download_id = data.get("download_id") or data.get("id")
+    if not download_id:
+        return web.json_response({"error": "Missing 'download_id'."}, status=400)
+
+    try:
+        result = await asyncio.to_thread(download_manager.delete_downloaded_item, str(download_id))
+    except Exception as exc:
+        print(f"[Civicomfy] Unexpected error while deleting {download_id}: {exc}")
+        return web.json_response(
+            {
+                "error": "Internal Server Error",
+                "details": f"Failed to delete download: {exc}",
+            },
+            status=500,
+        )
+
+    status_code = 200 if result.get("success") else 400
+    error_text = (result.get("error") or "").lower()
+    if not result.get("success") and "not found" in error_text:
+        status_code = 404
+
+    return web.json_response(result, status=status_code)

--- a/server/routes/GetLibrary.py
+++ b/server/routes/GetLibrary.py
@@ -1,0 +1,30 @@
+# ================================================
+# File: server/routes/GetLibrary.py
+# ================================================
+import asyncio
+from aiohttp import web
+
+import server  # ComfyUI server instance
+from ...downloader.manager import manager as download_manager
+
+prompt_server = server.PromptServer.instance
+
+
+@prompt_server.routes.get("/civitai/library")
+async def route_get_library(request):
+    """Return the list of downloaded models for the library view."""
+    if not download_manager:
+        return web.json_response({"error": "Download manager not initialized."}, status=500)
+
+    try:
+        items = await asyncio.to_thread(download_manager.get_library_items)
+        return web.json_response({"items": items})
+    except Exception as exc:
+        print(f"[Civicomfy] Error building library payload: {exc}")
+        return web.json_response(
+            {
+                "error": "Internal Server Error",
+                "details": f"Failed to read library items: {exc}",
+            },
+            status=500,
+        )

--- a/server/routes/__init__.py
+++ b/server/routes/__init__.py
@@ -13,9 +13,11 @@ from . import GetBaseModels
 from . import GetModelDetails
 from . import GetModelTypes
 from . import GetModelDirs
+from . import GetLibrary
 from . import GetStatus
 from . import OpenPath
 from . import RetryDownload
 from . import SearchModels
+from . import DeleteLibraryItem
 
 print("[Civicomfy] All server route modules loaded.")

--- a/web/js/api/civitai.js
+++ b/web/js/api/civitai.js
@@ -111,6 +111,18 @@ export class CivitaiDownloaderAPI {
     return await this._request(`/civitai/model_dirs?type=${q}`);
   }
 
+  static async getLibrary() {
+    return await this._request("/civitai/library");
+  }
+
+  static async deleteLibraryItem(downloadId) {
+    return await this._request("/civitai/library/delete", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ download_id: downloadId }),
+    });
+  }
+
   static async createModelDir(modelType, newDir) {
     return await this._request("/civitai/create_dir", {
       method: "POST",

--- a/web/js/civitaiDownloader.css
+++ b/web/js/civitaiDownloader.css
@@ -897,3 +897,129 @@
     border-color: rgba(21, 101, 192, 0.55);
     box-shadow: 0 0 0 1px rgba(21, 101, 192, 0.35);
 }
+
+/* Library tab */
+.civitai-library-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 16px;
+}
+
+.civitai-library-control-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.civitai-library-count {
+    font-size: 0.95em;
+    color: #bbb;
+}
+
+.civitai-library-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.civitai-library-item {
+    display: flex;
+    gap: 16px;
+    align-items: stretch;
+    padding: 14px;
+    border: 1px solid var(--border-color, #444);
+    border-radius: 8px;
+    background-color: rgba(255, 255, 255, 0.02);
+}
+
+.civitai-library-item.missing {
+    border-color: rgba(255, 107, 107, 0.6);
+    background-color: rgba(255, 107, 107, 0.08);
+}
+
+.civitai-library-details {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.civitai-library-title {
+    font-size: 1.1em;
+    font-weight: 600;
+}
+
+.civitai-library-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    font-size: 0.9em;
+    color: #bbb;
+}
+
+.civitai-library-status {
+    font-weight: 600;
+}
+
+.civitai-library-status.status-ok {
+    color: #7fd27f;
+}
+
+.civitai-library-status.status-missing {
+    color: #ff6b6b;
+}
+
+.civitai-library-path {
+    font-family: var(--comfy-code-font, monospace);
+    font-size: 0.85em;
+    color: #ccc;
+    word-break: break-word;
+}
+
+.civitai-library-date {
+    font-size: 0.85em;
+    color: #aaa;
+}
+
+.civitai-library-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.civitai-library-pill {
+    background-color: rgba(92, 138, 255, 0.15);
+    border: 1px solid rgba(92, 138, 255, 0.4);
+    border-radius: 999px;
+    padding: 4px 10px;
+    font-size: 0.8em;
+    cursor: pointer;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.civitai-library-pill:hover {
+    background-color: rgba(92, 138, 255, 0.3);
+    border-color: rgba(92, 138, 255, 0.8);
+}
+
+.civitai-library-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    justify-content: center;
+}
+
+.civitai-library-actions .civitai-button.small {
+    min-width: 36px;
+}
+
+.civitai-library-empty {
+    color: #bbb;
+    text-align: center;
+    padding: 24px 12px;
+    border: 1px dashed var(--border-color, #444);
+    border-radius: 8px;
+}

--- a/web/js/ui/handlers/settingsHandler.js
+++ b/web/js/ui/handlers/settingsHandler.js
@@ -70,12 +70,6 @@ export function applySettings(ui) {
         const val = Number(ui.settings.nsfwBlurMinLevel);
         ui.settingsNsfwThresholdInput.value = Number.isFinite(val) ? val : 4;
     }
-    if (ui.downloadConnectionsInput) {
-        ui.downloadConnectionsInput.value = Math.max(1, Math.min(16, ui.settings.numConnections || 1));
-    }
-    if (ui.downloadModelTypeSelect && Object.keys(ui.modelTypes).length > 0) {
-        ui.downloadModelTypeSelect.value = ui.settings.defaultModelType || 'checkpoint';
-    }
     ui.searchPagination.limit = ui.settings.searchResultLimit || 20;
 
     if (typeof ui.updateMergedUIState === 'function') {

--- a/web/js/ui/handlers/statusHandler.js
+++ b/web/js/ui/handlers/statusHandler.js
@@ -43,6 +43,8 @@ export async function updateStatus(ui) {
             ui.renderDownloadList(ui.statusData.active, ui.activeListContainer, 'No active downloads.');
             ui.renderDownloadList(ui.statusData.queue, ui.queuedListContainer, 'Download queue is empty.');
             ui.renderDownloadList(ui.statusData.history, ui.historyListContainer, 'No download history yet.');
+        } else if (ui.activeTab === 'library') {
+            ui.loadLibraryItems(false);
         }
     } catch (error) {
         console.error("[Civicomfy] Failed to update status:", error);

--- a/web/js/ui/libraryRenderer.js
+++ b/web/js/ui/libraryRenderer.js
@@ -1,0 +1,90 @@
+const PLACEHOLDER_IMAGE_URL = `/extensions/Civicomfy/images/placeholder.jpeg`;
+
+function escapeHtml(value = "") {
+  return String(value).replace(/[&<>"']/g, (match) => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+  })[match]);
+}
+
+function formatDate(value) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleString();
+}
+
+export function renderLibraryList(ui, items = []) {
+  if (!ui.libraryListContainer) return;
+
+  if (!Array.isArray(items) || items.length === 0) {
+    ui.libraryListContainer.innerHTML = '<p class="civitai-library-empty">No downloaded models yet. Queue downloads from the Search tab.</p>';
+    ui.ensureFontAwesome();
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  const blurEnabled = ui.settings?.hideMatureInSearch === true;
+  const blurThreshold = Number(ui.settings?.nsfwBlurMinLevel ?? 4);
+
+  items.forEach((item) => {
+    const id = item.id || "";
+    const modelName = item.model_name || "Unknown Model";
+    const versionName = item.version_name || "Unknown Version";
+    const typeName = item.model_type || "";
+    const resolvedType = typeName && ui.modelTypes ? ui.modelTypes[typeName] || typeName : typeName;
+    const sizeText = item.size_bytes ? ui.formatBytes(item.size_bytes) : "";
+    const downloadedAt = formatDate(item.downloaded_at);
+    const exists = item.exists !== false;
+    const path = item.path || "Not available";
+    const nsfwLevel = Number(item.thumbnail_nsfw_level ?? 0);
+    const shouldBlur = blurEnabled && Number.isFinite(nsfwLevel) && nsfwLevel >= blurThreshold;
+    const onDiskText = exists ? "On disk" : (item.deleted ? "Deleted" : "Missing");
+    const trainedWords = Array.isArray(item.trained_words) ? item.trained_words : [];
+
+    const container = document.createElement("div");
+    container.className = `civitai-library-item${exists ? "" : " missing"}`;
+    container.dataset.id = id;
+
+    const thumbContainerClass = `civitai-thumbnail-container${shouldBlur ? " blurred" : ""}`;
+    const overlayHtml = shouldBlur ? '<div class="civitai-nsfw-overlay" title="R-rated: click to reveal">R</div>' : '';
+    const onError = `this.onerror=null; this.src='${PLACEHOLDER_IMAGE_URL}';`;
+
+    const trainedHtml = trainedWords
+      .slice(0, 6)
+      .map((word) => `<span class="civitai-library-pill" title="Copy trigger">${escapeHtml(word)}</span>`)
+      .join("");
+
+    container.innerHTML = `
+      <div class="${thumbContainerClass}" data-nsfw-level="${Number.isFinite(nsfwLevel) ? nsfwLevel : ''}">
+        <img src="${escapeHtml(item.thumbnail || PLACEHOLDER_IMAGE_URL)}" alt="${escapeHtml(modelName)}" class="civitai-download-thumbnail" loading="lazy" onerror="${onError}">
+        ${overlayHtml}
+      </div>
+      <div class="civitai-library-details">
+        <div class="civitai-library-title">${escapeHtml(modelName)}</div>
+        <div class="civitai-library-meta">
+          <span title="Version">Ver: ${escapeHtml(versionName)}</span>
+          ${resolvedType ? `<span title="Model type">${escapeHtml(resolvedType)}</span>` : ''}
+          ${sizeText ? `<span title="File size">${escapeHtml(sizeText)}</span>` : ''}
+          <span class="civitai-library-status ${exists ? 'status-ok' : 'status-missing'}">${escapeHtml(onDiskText)}</span>
+        </div>
+        <div class="civitai-library-path" title="${escapeHtml(path)}">${escapeHtml(path)}</div>
+        ${downloadedAt ? `<div class="civitai-library-date">Downloaded: ${escapeHtml(downloadedAt)}</div>` : ''}
+        ${trainedHtml ? `<div class="civitai-library-tags" data-id="${escapeHtml(id)}">${trainedHtml}</div>` : ''}
+      </div>
+      <div class="civitai-library-actions">
+        <button class="civitai-button small civitai-library-open" data-id="${escapeHtml(id)}" ${exists ? '' : 'disabled'} title="Open containing folder"><i class="fas fa-folder-open"></i></button>
+        <button class="civitai-button danger small civitai-library-delete" data-id="${escapeHtml(id)}" title="Remove from disk"><i class="fas fa-trash-alt"></i></button>
+      </div>
+    `;
+
+    fragment.appendChild(container);
+  });
+
+  ui.libraryListContainer.innerHTML = "";
+  ui.libraryListContainer.appendChild(fragment);
+  ui.ensureFontAwesome();
+}

--- a/web/js/ui/templates.js
+++ b/web/js/ui/templates.js
@@ -2,7 +2,6 @@
 // Keep structure identical to the original inline HTML to minimize risk
 
 export function modalTemplate(settings = {}) {
-  const numConnections = Number.isFinite(settings.numConnections) ? settings.numConnections : 1;
   return `
     <div class="civitai-downloader-modal-content">
       <div class="civitai-downloader-header">
@@ -11,60 +10,22 @@ export function modalTemplate(settings = {}) {
       </div>
       <div class="civitai-downloader-body">
         <div class="civitai-downloader-tabs">
-          <button class="civitai-downloader-tab active" data-tab="download">Download</button>
+          <button class="civitai-downloader-tab active" data-tab="library">Library</button>
           <button class="civitai-downloader-tab" data-tab="search">Search</button>
           <button class="civitai-downloader-tab" data-tab="status">Status <span id="civitai-status-indicator" style="display: none;">(<span id="civitai-active-count">0</span>)</span></button>
           <button class="civitai-downloader-tab" data-tab="settings">Settings</button>
         </div>
-        <div id="civitai-tab-download" class="civitai-downloader-tab-content active">
-          <form id="civitai-download-form">
-            <div class="civitai-form-group">
-              <label for="civitai-model-url">Model URL or ID</label>
-              <input type="text" id="civitai-model-url" class="civitai-input" placeholder="e.g., https://civitai.com/models/12345 or 12345" required>
+        <div id="civitai-tab-library" class="civitai-downloader-tab-content active">
+          <div class="civitai-library-controls">
+            <input type="text" id="civitai-library-search" class="civitai-input" placeholder="Filter downloaded models...">
+            <div class="civitai-library-control-actions">
+              <span id="civitai-library-count" class="civitai-library-count">0 models</span>
+              <button type="button" id="civitai-library-refresh" class="civitai-button small"><i class="fas fa-sync-alt"></i> Refresh</button>
             </div>
-            <p style="font-size: 0.9em; color: #ccc; margin-top: -10px; margin-bottom: 15px;">You can optionally specify a version ID using "?modelVersionId=xxxxx" in the URL or in the field below.</p>
-            <div class="civitai-form-row">
-              <div class="civitai-form-group">
-                <label for="civitai-model-type">Model Type (Save Location)</label>
-                <div style="display:flex; gap:6px; align-items:center;">
-                  <select id="civitai-model-type" class="civitai-select" required></select>
-                  <button type="button" id="civitai-create-model-type" class="civitai-button small" title="Create new model type folder"><i class="fas fa-folder-plus"></i></button>
-                </div>
-              </div>
-              <div class="civitai-form-group">
-                <label for="civitai-subdir-select">Save Subfolder</label>
-                <div style="display:flex; gap:6px; align-items:center;">
-                  <select id="civitai-subdir-select" class="civitai-select">
-                    <option value="">(root)</option>
-                  </select>
-                  <button type="button" id="civitai-create-subdir" class="civitai-button small" title="Create new subfolder"><i class="fas fa-folder-plus"></i></button>
-                </div>
-              </div>
-              <div class="civitai-form-group">
-                <label for="civitai-model-version-id">Version ID (Optional)</label>
-                <input type="number" id="civitai-model-version-id" class="civitai-input" placeholder="Overrides URL/Latest">
-              </div>
-            </div>
-            <div class="civitai-form-row">
-              <div class="civitai-form-group">
-                <label for="civitai-custom-filename">Custom Filename (Optional)</label>
-                <input type="text" id="civitai-custom-filename" class="civitai-input" placeholder="Leave blank to use original name">
-              </div>
-              <div class="civitai-form-group">
-                <label for="civitai-connections">Connections</label>
-                <input type="number" id="civitai-connections" class="civitai-input" value="${numConnections}" min="1" max="16" step="1" required disabled>
-                <p style="font-size: 0.9em; color: #ccc; margin-top: 7px; margin-bottom: 15px;">Disabled: Only single connection possible for now</p>
-              </div>
-            </div>
-            <div class="civitai-form-group inline">
-              <input type="checkbox" id="civitai-force-redownload" class="civitai-checkbox">
-              <label for="civitai-force-redownload">Force Re-download (if exists)</label>
-            </div>
-            <div id="civitai-download-preview-area" class="civitai-download-preview-area" style="margin-top: 25px; margin-bottom: 25px; padding-top: 15px; border-top: 1px solid var(--border-color, #444);">
-              <!-- Preview content will be injected here -->
-            </div>
-            <button type="submit" id="civitai-download-submit" class="civitai-button primary">Start Download</button>
-          </form>
+          </div>
+          <div id="civitai-library-list" class="civitai-library-list">
+            <p class="civitai-library-empty">No downloaded models yet. Queue downloads from the Search tab.</p>
+          </div>
         </div>
         <div id="civitai-tab-search" class="civitai-downloader-tab-content">
           <form id="civitai-search-form">


### PR DESCRIPTION
## Summary
- add library retrieval and deletion helpers on the downloader plus REST endpoints for listing/deleting library items
- convert the former download tab into a library UI with filtering, refresh, and open/delete actions for downloaded models
- refresh supporting scripts, styles, and status updates to keep the library in sync and copy trained words quickly

## Testing
- python -m compileall Civicomfy

------
https://chatgpt.com/codex/tasks/task_e_68cab80e80348325bac1d360e17d579a