### PR TITLE
Auto-structure search downloads by base model

### DIFF
--- a/web/js/ui/searchRenderer.js
+++ b/web/js/ui/searchRenderer.js
@@ -24,6 +24,7 @@ export function createCardElement(model) {
   card.className = 'civi-card';
   card.dataset.modelId = model.modelId;
   card.dataset.modelType = model.modelType || '';
+  card.dataset.baseModel = model.baseModel || '';
   card.dataset.modelName = model.title || '';
   card.dataset.versionId = model.versionId || '';
   card.dataset.versionName = model.versionName || '';


### PR DESCRIPTION
## Summary
- capture each search result's base model on the card metadata
- derive the default download subdirectory as model type → base model → model → version
- ensure the quick download drawer preselects the inferred model type while populating nested folders

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68cad384cc088325b8ff99e78c820bf4