### PR TITLE
Improve search download path controls

### DIFF
--- a/web/js/civitaiDownloader.css
+++ b/web/js/civitaiDownloader.css
@@ -830,6 +830,44 @@
     gap: 12px;
     align-items: start;
 }
+
+.civi-drawer-targets {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    font-size: 0.9rem;
+}
+
+.civi-drawer-targets label {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.civi-drawer-targets input,
+.civi-drawer-targets select {
+    padding: 6px 8px;
+    border-radius: 6px;
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    background: rgba(0, 0, 0, 0.35);
+    color: inherit;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.civi-folder-fields {
+    display: grid;
+    gap: 6px;
+}
+
+.civi-path-preview {
+    font-size: 0.8rem;
+    color: rgba(255, 255, 255, 0.75);
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: 6px;
+    padding: 6px 8px;
+    word-break: break-all;
+}
 .civi-files-list {
     max-height: 180px;
     overflow: auto;

--- a/web/js/ui/searchRenderer.js
+++ b/web/js/ui/searchRenderer.js
@@ -65,12 +65,21 @@ export function createCardElement(model) {
         </div>
 
         <div class="civi-drawer-targets">
-          <label>Target location:
+          <label>Model type:
             <select class="civi-target-root"></select>
           </label>
-          <label>Subfolder:
-            <input class="civi-subdir-input" placeholder="optional subfolder">
-          </label>
+          <div class="civi-folder-fields">
+            <label>Base model folder:
+              <input class="civi-base-folder-input" placeholder="e.g. Illustrious">
+            </label>
+            <label>Model name folder:
+              <input class="civi-model-folder-input" placeholder="e.g. catslora">
+            </label>
+            <label>Version folder:
+              <input class="civi-version-folder-input" placeholder="e.g. catsv1">
+            </label>
+          </div>
+          <div class="civi-path-preview" aria-live="polite"></div>
           <label>Filename override:
             <input class="civi-filename-input" placeholder="optional filename.safetensors">
           </label>
@@ -203,9 +212,31 @@ export function populateDrawerWithDetails(cardEl, details, modelTypeOptions = []
     }
   }
 
-  const subdirInput = cardEl.querySelector('.civi-subdir-input');
-  if (subdirInput && defaults?.subdir !== undefined) {
-    subdirInput.value = defaults.subdir;
+  const baseInput = cardEl.querySelector('.civi-base-folder-input');
+  if (baseInput && defaults?.baseFolder !== undefined) {
+    baseInput.value = defaults.baseFolder || '';
+    if (cardEl.dataset) {
+      cardEl.dataset.autoBaseFolder = defaults.baseFolder || '';
+      cardEl.dataset.userBaseFolderDirty = 'false';
+    }
+  }
+
+  const modelInput = cardEl.querySelector('.civi-model-folder-input');
+  if (modelInput && defaults?.modelFolder !== undefined) {
+    modelInput.value = defaults.modelFolder || '';
+    if (cardEl.dataset) {
+      cardEl.dataset.autoModelFolder = defaults.modelFolder || '';
+      cardEl.dataset.userModelFolderDirty = 'false';
+    }
+  }
+
+  const versionInput = cardEl.querySelector('.civi-version-folder-input');
+  if (versionInput && defaults?.versionFolder !== undefined) {
+    versionInput.value = defaults.versionFolder || '';
+    if (cardEl.dataset) {
+      cardEl.dataset.autoVersionFolder = defaults.versionFolder || '';
+      cardEl.dataset.userVersionFolderDirty = 'false';
+    }
   }
 
   const filenameInput = cardEl.querySelector('.civi-filename-input');


### PR DESCRIPTION
## Summary
- add dedicated base/model/version folder inputs and a live path preview to the search download drawer
- auto-generate sanitized folder segments, keep them synced with version changes, and build queue payloads from the separate fields
- style the new folder controls to fit the existing drawer layout

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cad82ecdb8832583cf07fc534cd1cc