### PR TITLE
Library: Add Edit tags & triggers drawer to downloaded cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Civicomfy seamlessly integrates Civitai's vast model repository directly into Co
 - **Integrated Model Search**: Search Civitai's extensive library directly from ComfyUI
 - **One-Click Downloads**: Download models with associated metadata and thumbnails
 - **Automatic Organization**: Models are automatically saved to their appropriate directories
+- **Tag & Trigger Management**: Curate custom tags and triggers on library cards with a keyboard-friendly drawer
 - **Clean UI**: Clean, intuitive interface that complements ComfyUI's aesthetic
 
 ## Installation
@@ -48,6 +49,7 @@ Workflows and attachments are persisted under the extension folder as JSON.
 Storage files:
 - `workflows.json`: { version, workflows: [ { workflow_id, name, node_list, connections, metadata } ] }
 - `card_meta.json`: { version, cards: { <download_id>: { workflow_ids:[], single_node_binding:{ node_type, widget } } } }
+  - Each card entry also persists `custom_tags` and `custom_triggers` arrays for user-added metadata.
 
 Minimal REST API:
 - `GET /civitai/workflows?card_id=<optional>` → { workflows:[{ workflow_id, name, node_count, connection_count, metadata }] }

--- a/tests/test_card_meta.py
+++ b/tests/test_card_meta.py
@@ -1,0 +1,60 @@
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+if 'folder_paths' not in sys.modules:
+    sys.modules['folder_paths'] = SimpleNamespace(base_path=str(ROOT))
+
+from Civicomfy.utils import card_meta
+
+
+def test_sanitize_custom_list_trims_and_dedupes():
+    values = [' Foo ', 'foo', 'BAR', 'bar ', '', '   ', None, 123]
+    result = card_meta.sanitize_custom_list(values)
+    assert result == ['Foo', 'BAR', '123']
+
+
+def test_normalize_card_entry_sanitizes_binding_and_lists():
+    entry = {
+        'workflow_ids': ['wf1', 'WF1', '  '],
+        'single_node_binding': {'node_type': '  Loader  ', 'widget': '  node  '},
+        'custom_tags': ['Alpha', 'alpha', ''],
+        'custom_triggers': ['Beta', None, 'beta'],
+        'extra_field': 5,
+    }
+    normalized = card_meta.normalize_card_entry(entry)
+    assert normalized['workflow_ids'] == ['wf1', 'WF1']
+    assert normalized['single_node_binding'] == {'node_type': 'Loader', 'widget': 'node'}
+    assert normalized['custom_tags'] == ['Alpha']
+    assert normalized['custom_triggers'] == ['Beta']
+    assert normalized['extra_field'] == 5
+
+
+def test_update_card_custom_lists_persists(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    meta_path = tmp_path / 'card_meta.json'
+    monkeypatch.setattr(card_meta, 'CARD_META_PATH', str(meta_path))
+    card_meta.ensure_card_meta_file()
+
+    updated = card_meta.update_card_custom_lists(
+        'card123',
+        custom_tags=[' Tag ', 'tag', 'Another'],
+        custom_triggers=['Trigger', 'TRIGGER', ''],
+    )
+    assert updated['custom_tags'] == ['Tag', 'Another']
+    assert updated['custom_triggers'] == ['Trigger']
+
+    data = card_meta.load_card_meta()
+    assert data['cards']['card123']['custom_tags'] == ['Tag', 'Another']
+    assert data['cards']['card123']['custom_triggers'] == ['Trigger']
+
+    with open(meta_path, 'r', encoding='utf-8') as handle:
+        raw = json.load(handle)
+    assert raw['cards']['card123']['custom_tags'] == ['Tag', 'Another']
+    assert raw['cards']['card123']['custom_triggers'] == ['Trigger']

--- a/utils/card_meta.py
+++ b/utils/card_meta.py
@@ -1,0 +1,190 @@
+"""Utilities for reading and writing Civicomfy card metadata.
+
+Provides helpers to load, sanitize, and update ``card_meta.json``
+which stores card-scoped configuration such as workflow attachments
+and user-defined tags/triggers.
+"""
+from __future__ import annotations
+
+import json
+import os
+import threading
+from typing import Any, Dict, Iterable, List
+
+from ..config import PLUGIN_ROOT
+
+CARD_META_PATH = os.path.join(PLUGIN_ROOT, "card_meta.json")
+_DEFAULT_META: Dict[str, Any] = {"version": 1, "cards": {}}
+_KNOWN_KEYS = {"workflow_ids", "single_node_binding", "custom_tags", "custom_triggers"}
+_LOCK = threading.Lock()
+
+_MAX_CUSTOM_ITEMS = 64
+_MAX_CUSTOM_LENGTH = 120
+
+
+def _read_file() -> Dict[str, Any]:
+    if os.path.exists(CARD_META_PATH):
+        try:
+            with open(CARD_META_PATH, "r", encoding="utf-8") as handle:
+                data = json.load(handle)
+                if isinstance(data, dict):
+                    return data
+        except Exception as exc:  # pragma: no cover - log but continue with defaults
+            print(f"[Civicomfy] Warning: failed to read card meta ({CARD_META_PATH}): {exc}")
+    return dict(_DEFAULT_META)
+
+
+def _write_file(payload: Dict[str, Any]) -> None:
+    tmp_path = CARD_META_PATH + ".tmp"
+    with open(tmp_path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, ensure_ascii=False)
+    os.replace(tmp_path, CARD_META_PATH)
+
+
+def ensure_card_meta_file() -> None:
+    """Ensure the metadata file exists on disk."""
+    with _LOCK:
+        if not os.path.exists(CARD_META_PATH):
+            _write_file(dict(_DEFAULT_META))
+
+
+def sanitize_custom_list(values: Iterable[Any] | None) -> List[str]:
+    """Return a trimmed, de-duplicated list of custom strings."""
+    if values is None:
+        return []
+    if isinstance(values, str):
+        values = [values]
+    if not isinstance(values, Iterable):
+        return []
+
+    cleaned: List[str] = []
+    seen: set[str] = set()
+    for raw in values:
+        if raw is None:
+            continue
+        text = str(raw).strip()
+        if not text:
+            continue
+        if len(text) > _MAX_CUSTOM_LENGTH:
+            text = text[:_MAX_CUSTOM_LENGTH].strip()
+        lowered = text.casefold()
+        if lowered in seen:
+            continue
+        seen.add(lowered)
+        cleaned.append(text)
+        if len(cleaned) >= _MAX_CUSTOM_ITEMS:
+            break
+    return cleaned
+
+
+def _sanitize_workflow_ids(values: Any) -> List[str]:
+    if not isinstance(values, list):
+        return []
+    result: List[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if value is None:
+            continue
+        text = str(value).strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        result.append(text)
+    return result
+
+
+def _sanitize_binding(binding: Any) -> Dict[str, str] | None:
+    if not isinstance(binding, dict):
+        return None
+    node_type = binding.get("node_type")
+    if not isinstance(node_type, str) or not node_type.strip():
+        return None
+    widget = binding.get("widget", "")
+    widget_text = str(widget).strip() if widget is not None else ""
+    return {"node_type": node_type.strip(), "widget": widget_text}
+
+
+def normalize_card_entry(entry: Any | None) -> Dict[str, Any]:
+    """Return a sanitized card entry with default keys present."""
+    source = entry if isinstance(entry, dict) else {}
+    normalized: Dict[str, Any] = {
+        "workflow_ids": _sanitize_workflow_ids(source.get("workflow_ids")),
+        "single_node_binding": _sanitize_binding(source.get("single_node_binding")),
+        "custom_tags": sanitize_custom_list(source.get("custom_tags")),
+        "custom_triggers": sanitize_custom_list(source.get("custom_triggers")),
+    }
+    for key, value in source.items():
+        if key not in _KNOWN_KEYS:
+            normalized[key] = value
+    return normalized
+
+
+def load_card_meta() -> Dict[str, Any]:
+    """Load and sanitize card metadata from disk."""
+    ensure_card_meta_file()
+    with _LOCK:
+        raw = _read_file()
+    version = raw.get("version", 1)
+    cards = raw.get("cards")
+    sanitized_cards: Dict[str, Any] = {}
+    if isinstance(cards, dict):
+        for card_id, data in cards.items():
+            if not isinstance(card_id, str):
+                continue
+            sanitized_cards[card_id] = normalize_card_entry(data)
+    return {"version": version, "cards": sanitized_cards}
+
+
+def save_card_meta(meta: Dict[str, Any]) -> None:
+    """Persist sanitized metadata back to disk."""
+    if not isinstance(meta, dict):
+        raise ValueError("card meta must be a dict")
+    version = meta.get("version", 1)
+    cards = meta.get("cards")
+    normalized_cards: Dict[str, Any] = {}
+    if isinstance(cards, dict):
+        for card_id, data in cards.items():
+            if not isinstance(card_id, str):
+                continue
+            normalized_cards[card_id] = normalize_card_entry(data)
+    payload = {"version": version, "cards": normalized_cards}
+    ensure_card_meta_file()
+    with _LOCK:
+        _write_file(payload)
+
+
+def ensure_card_entry(meta: Dict[str, Any], card_id: str) -> Dict[str, Any]:
+    """Ensure *card_id* exists in *meta* and return the sanitized entry."""
+    if not isinstance(card_id, str) or not card_id:
+        raise ValueError("card_id must be a non-empty string")
+    cards = meta.setdefault("cards", {})
+    if not isinstance(cards, dict):
+        cards = {}
+        meta["cards"] = cards
+    entry = normalize_card_entry(cards.get(card_id))
+    cards[card_id] = entry
+    return entry
+
+
+def get_card_entry(card_id: str) -> Dict[str, Any]:
+    """Convenience helper to fetch a single card entry."""
+    meta = load_card_meta()
+    entry = meta["cards"].get(card_id)
+    if entry is None:
+        entry = normalize_card_entry(None)
+    return entry
+
+
+def update_card_custom_lists(card_id: str, *, custom_tags: Iterable[Any] | None, custom_triggers: Iterable[Any] | None) -> Dict[str, Any]:
+    """Update user-defined tags and triggers for *card_id* and persist the change."""
+    if not isinstance(card_id, str) or not card_id:
+        raise ValueError("card_id must be a non-empty string")
+    meta = load_card_meta()
+    entry = ensure_card_entry(meta, card_id)
+    if custom_tags is not None:
+        entry["custom_tags"] = sanitize_custom_list(custom_tags)
+    if custom_triggers is not None:
+        entry["custom_triggers"] = sanitize_custom_list(custom_triggers)
+    meta["cards"][card_id] = entry
+    save_card_meta(meta)
+    return entry

--- a/web/js/api/civitai.js
+++ b/web/js/api/civitai.js
@@ -235,6 +235,18 @@ export class CivitaiDownloaderAPI {
     });
   }
 
+  static async getCardMeta(cardId) {
+    return await this._request(`/civitai/cards/${encodeURIComponent(cardId)}/meta`);
+  }
+
+  static async updateCardMeta(cardId, payload) {
+    return await this._request(`/civitai/cards/${encodeURIComponent(cardId)}/meta`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload || {}),
+    });
+  }
+
   static async exportWorkflows() {
     return await this._request(`/civitai/workflows/export`);
   }

--- a/web/js/civitaiDownloader.css
+++ b/web/js/civitaiDownloader.css
@@ -1110,6 +1110,12 @@
     border-color: rgba(92, 138, 255, 0.8);
 }
 
+.civitai-library-pill.civitai-library-pill-custom {
+    background-color: rgba(97, 202, 115, 0.22);
+    border-color: rgba(97, 202, 115, 0.6);
+    color: #ddf8e4;
+}
+
 .civitai-library-actions {
     display: flex;
     flex-direction: column;
@@ -1127,4 +1133,260 @@
     padding: 24px 12px;
     border: 1px dashed var(--border-color, #444);
     border-radius: 8px;
+}
+
+.civitai-library-edit-meta {
+    position: relative;
+}
+
+.civitai-library-edit-meta.has-custom::after {
+    content: "";
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #7fd27f;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.4);
+}
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+/* Card metadata drawer */
+.civitai-card-meta-container {
+    position: absolute;
+    inset: 0;
+    display: none;
+    align-items: stretch;
+    justify-content: flex-end;
+    z-index: 5;
+}
+
+.civitai-card-meta-container.open {
+    display: flex;
+}
+
+.civitai-card-meta-backdrop {
+    flex: 1;
+    background: rgba(0, 0, 0, 0.4);
+}
+
+.civitai-card-meta-drawer {
+    width: 420px;
+    max-width: 90%;
+    height: 100%;
+    background: var(--comfy-menu-bg);
+    color: var(--comfy-text-color);
+    border-left: 1px solid var(--border-color, #444);
+    box-shadow: -8px 0 24px rgba(0, 0, 0, 0.45);
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    overflow-y: auto;
+}
+
+.civitai-card-meta-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+}
+
+.civitai-card-meta-title-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.civitai-card-meta-subtitle {
+    margin: 0;
+    font-size: 0.9em;
+    color: #b5b5b5;
+}
+
+.civitai-card-meta-close {
+    background: none;
+    border: none;
+    color: var(--comfy-text-color);
+    font-size: 26px;
+    line-height: 1;
+    cursor: pointer;
+    padding: 2px 6px;
+}
+
+.civitai-card-meta-close:hover {
+    color: #fff;
+}
+
+.civitai-card-meta-body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    overflow-y: auto;
+    padding-right: 4px;
+}
+
+.civitai-card-meta-section {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.civitai-chip-editor {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.civitai-chip-editor-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.civitai-chip-editor-title {
+    margin: 0;
+    font-size: 1.05em;
+}
+
+.civitai-chip-editor-input-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.civitai-chip-editor-field {
+    flex: 1;
+    padding: 8px 10px;
+    background: var(--comfy-input-bg);
+    color: var(--comfy-text-color);
+    border: 1px solid var(--border-color, #555);
+    border-radius: 4px;
+}
+
+.civitai-chip-editor-field:focus {
+    outline: none;
+    border-color: var(--accent-color, #5c8aff);
+    box-shadow: 0 0 0 2px rgba(92, 138, 255, 0.25);
+}
+
+.civitai-chip-editor-add,
+.civitai-chip-editor-add-all {
+    background: var(--comfy-input-bg);
+    border: 1px solid var(--border-color, #555);
+    color: var(--comfy-text-color);
+    border-radius: 4px;
+    cursor: pointer;
+    padding: 6px 12px;
+    font-size: 0.9em;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.civitai-chip-editor-add {
+    min-width: 38px;
+    padding: 6px 10px;
+}
+
+.civitai-chip-editor-add:hover,
+.civitai-chip-editor-add-all:hover {
+    background-color: var(--comfy-input-bg-hover, rgba(255,255,255,0.04));
+}
+
+.civitai-chip-editor-add:disabled,
+.civitai-chip-editor-add-all:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+}
+
+.civitai-chip-editor-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.civitai-chip-editor-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background-color: rgba(92, 138, 255, 0.15);
+    border: 1px solid rgba(92, 138, 255, 0.4);
+    border-radius: 999px;
+    padding: 4px 10px;
+    font-size: 0.8em;
+}
+
+.civitai-chip-editor-chip-remove {
+    background: none;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    font-size: 16px;
+    line-height: 1;
+    padding: 0;
+}
+
+.civitai-chip-editor-chip-remove:hover {
+    color: #fff;
+}
+
+.civitai-chip-editor-helper {
+    margin: 0;
+    font-size: 0.85em;
+    color: #9ca3af;
+}
+
+.civitai-card-meta-preview {
+    border-top: 1px solid var(--border-color, #444);
+    padding-top: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.civitai-card-meta-preview h4 {
+    margin: 0;
+}
+
+.civitai-card-meta-preview-group {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.civitai-card-meta-preview-label {
+    font-size: 0.85em;
+    color: #b5b5b5;
+}
+
+.civitai-card-meta-preview-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.civitai-card-meta-preview-empty {
+    font-size: 0.85em;
+    color: #8f8f8f;
+}
+
+.civitai-card-meta-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    border-top: 1px solid var(--border-color, #444);
+    padding-top: 12px;
 }

--- a/web/js/ui/chipEditor.js
+++ b/web/js/ui/chipEditor.js
@@ -1,0 +1,223 @@
+let editorId = 0;
+
+function escapeHtml(value = "") {
+  return String(value).replace(/[&<>"']/g, (match) => ({
+    "&": "&amp;",
+    "<": "&lt;",
+    ">": "&gt;",
+    '"': "&quot;",
+    "'": "&#39;",
+  })[match] || match);
+}
+
+function sanitizeList(values, limit = 512) {
+  if (!Array.isArray(values)) return [];
+  const cleaned = [];
+  const seen = new Set();
+  for (const value of values) {
+    if (value == null) continue;
+    const text = String(value).trim();
+    if (!text) continue;
+    const key = text.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    cleaned.push(text);
+    if (cleaned.length >= limit) break;
+  }
+  return cleaned;
+}
+
+export function createChipEditor(root, options = {}) {
+  if (!root) throw new Error("Chip editor root element is required");
+  const {
+    title = "Values",
+    inputLabel = "Add value",
+    placeholder = "Add value and press Enter",
+    addAllLabel = "Add all",
+    addButtonLabel = "Add",
+    helperText = "Press Enter or comma to add."
+  } = options;
+  const sourceValues = sanitizeList(options.sourceValues || []);
+  const inputId = `chip-editor-input-${++editorId}`;
+  const titleId = `chip-editor-title-${editorId}`;
+
+  root.classList.add("civitai-chip-editor");
+  root.innerHTML = `
+    <div class="civitai-chip-editor-header">
+      <h4 id="${titleId}" class="civitai-chip-editor-title">${escapeHtml(title)}</h4>
+      <div class="civitai-chip-editor-header-actions">
+        <button type="button" class="civitai-chip-editor-add-all" aria-describedby="${titleId}">${escapeHtml(addAllLabel)}</button>
+      </div>
+    </div>
+    <div class="civitai-chip-editor-input" role="group" aria-labelledby="${titleId}">
+      <label class="civitai-chip-editor-input-label" for="${inputId}">
+        <span class="visually-hidden">${escapeHtml(inputLabel)}</span>
+      </label>
+      <div class="civitai-chip-editor-input-row">
+        <input id="${inputId}" type="text" autocomplete="off" spellcheck="false" placeholder="${escapeHtml(placeholder)}" class="civitai-chip-editor-field">
+        <button type="button" class="civitai-chip-editor-add" aria-label="${escapeHtml(addButtonLabel)}">+</button>
+      </div>
+    </div>
+    <div class="civitai-chip-editor-chips" role="list" aria-live="polite"></div>
+    <p class="civitai-chip-editor-helper">${escapeHtml(helperText)}</p>
+  `;
+
+  const state = {
+    values: [],
+    source: sourceValues,
+  };
+
+  const chipsContainer = root.querySelector(".civitai-chip-editor-chips");
+  const inputEl = root.querySelector(".civitai-chip-editor-field");
+  const addButton = root.querySelector(".civitai-chip-editor-add");
+  const addAllButton = root.querySelector(".civitai-chip-editor-add-all");
+  const helperEl = root.querySelector(".civitai-chip-editor-helper");
+  const onChange = typeof options.onChange === "function" ? options.onChange : () => {};
+
+  function containsValue(value) {
+    const key = value.toLowerCase();
+    return state.values.some((v) => v.toLowerCase() === key);
+  }
+
+  function renderChips() {
+    chipsContainer.innerHTML = "";
+    state.values.forEach((value, index) => {
+      const chip = document.createElement("div");
+      chip.className = "civitai-chip-editor-chip";
+      chip.setAttribute("role", "listitem");
+      const textSpan = document.createElement("span");
+      textSpan.className = "civitai-chip-editor-chip-label";
+      textSpan.textContent = value;
+      const removeBtn = document.createElement("button");
+      removeBtn.type = "button";
+      removeBtn.className = "civitai-chip-editor-chip-remove";
+      removeBtn.setAttribute("aria-label", `Remove ${value}`);
+      removeBtn.innerHTML = "&times;";
+      removeBtn.addEventListener("click", () => {
+        state.values.splice(index, 1);
+        renderChips();
+        updateAddAllState();
+        onChange([...state.values]);
+        inputEl.focus();
+      });
+      chip.appendChild(textSpan);
+      chip.appendChild(removeBtn);
+      chipsContainer.appendChild(chip);
+    });
+    updateAddAllState();
+  }
+
+  function addValue(raw) {
+    if (!raw) return false;
+    const text = String(raw).trim();
+    if (!text) return false;
+    if (containsValue(text)) return false;
+    state.values.push(text);
+    return true;
+  }
+
+  function addValues(values) {
+    let added = false;
+    values.forEach((value) => {
+      if (addValue(value)) added = true;
+    });
+    if (added) {
+      renderChips();
+      onChange([...state.values]);
+    }
+    return added;
+  }
+
+  function commitInput() {
+    const raw = inputEl.value;
+    if (!raw) return false;
+    const pieces = raw.split(/[\n,]/).map((part) => part.trim()).filter(Boolean);
+    inputEl.value = "";
+    const added = addValues(pieces);
+    updateAddButtonState();
+    return added;
+  }
+
+  function updateAddButtonState() {
+    const text = inputEl.value.trim();
+    addButton.disabled = !text || containsValue(text);
+  }
+
+  function updateAddAllState() {
+    if (!addAllButton) return;
+    if (!Array.isArray(state.source) || state.source.length === 0) {
+      addAllButton.disabled = true;
+      if (helperEl && !helperEl.dataset.baseMessage) {
+        helperEl.dataset.baseMessage = helperEl.textContent || "";
+      }
+      return;
+    }
+    const missing = state.source.some((value) => !containsValue(value));
+    addAllButton.disabled = !missing;
+  }
+
+  addButton.addEventListener("click", () => {
+    commitInput();
+    inputEl.focus();
+  });
+
+  inputEl.addEventListener("keydown", (event) => {
+    if (event.key === "Enter" || event.key === ",") {
+      event.preventDefault();
+      commitInput();
+    } else if (event.key === "Backspace" && !inputEl.value) {
+      state.values.pop();
+      renderChips();
+      onChange([...state.values]);
+      updateAddAllState();
+    }
+  });
+
+  inputEl.addEventListener("input", updateAddButtonState);
+
+  inputEl.addEventListener("paste", (event) => {
+    try {
+      const text = event.clipboardData?.getData("text") || "";
+      if (text) {
+        event.preventDefault();
+        const pieces = text.split(/[\n,]/).map((part) => part.trim()).filter(Boolean);
+        addValues(pieces);
+        updateAddButtonState();
+      }
+    } catch (e) {
+      console.warn("Chip editor paste failed", e);
+    }
+  });
+
+  if (addAllButton) {
+    addAllButton.addEventListener("click", () => {
+      addValues(state.source);
+      updateAddAllState();
+      inputEl.focus();
+    });
+  }
+
+  updateAddAllState();
+  updateAddButtonState();
+
+  return {
+    getValues: () => [...state.values],
+    setValues: (values, silent = false) => {
+      const sanitized = sanitizeList(values, 256);
+      state.values = sanitized;
+      renderChips();
+      if (!silent) onChange([...state.values]);
+    },
+    setSourceValues: (values) => {
+      state.source = sanitizeList(values, 256);
+      updateAddAllState();
+    },
+    focus: () => {
+      inputEl.focus();
+    },
+    clearInput: () => {
+      inputEl.value = "";
+      updateAddButtonState();
+    },
+  };
+}

--- a/web/js/ui/handlers/eventListeners.js
+++ b/web/js/ui/handlers/eventListeners.js
@@ -88,6 +88,20 @@ export function setupEventListeners(ui) {
                     console.error('Workflow popup failed:', e);
                     ui.showToast('Failed to open workflow options', 'error');
                 }
+            } else if (button.classList.contains('civitai-library-edit-meta')) {
+                const container = button.closest('.civitai-library-item');
+                const id = container?.dataset?.id || button.dataset.id;
+                const item = Array.isArray(ui.libraryItems) ? ui.libraryItems.find(x => x && x.id === id) : null;
+                if (!item) {
+                    ui.showToast('Could not locate library item', 'error');
+                    return;
+                }
+                try {
+                    await ui.openCardMetaDrawer(item, button);
+                } catch (e) {
+                    console.error('Open tags/triggers drawer failed:', e);
+                    ui.showToast('Failed to open tags & triggers editor', 'error');
+                }
             }
         });
     }


### PR DESCRIPTION
## Summary
- persist user-defined tags and triggers in shared card metadata utilities and expose them via new `/meta` card routes
- include custom metadata when returning library items and add API client helpers for retrieving/updating card meta
- implement an accessible drawer with chip editors, indicator styling, and library wiring so users can edit and preview custom chips

## Testing
- pytest

## Checklist
* [x] Design: finalize drawer layout (header, Triggers/Tags chip inputs, Add-all, `+` add, Preview, Save/Cancel) and green-chip style.
* [x] Frontend: add opener button to card controls (aria-label + tooltip) and implement drawer open/close.
* [x] Frontend: implement chip-editor behavior (paste comma-separated, Enter → chip, removable chips, Add-all populates).
* [x] Frontend: show merged tags/triggers (server + custom); style user-added chips green and add green dot/state on opener icon.
* [x] API: wire GET card-meta and POST update-card-meta endpoints for `custom_tags` / `custom_triggers` (atomic writes + validation).
* [x] Storage: persist `custom_tags` / `custom_triggers` in card metadata so edits survive restarts.
* [x] Validation: trim whitespace, dedupe case-insensitively, prevent empty entries; disable Save if no changes.
* [x] Accessibility: trap focus in drawer, label inputs, keyboard add/remove chips, Esc to close, restore focus to opener.
* [x] Tests/QA: manual QA steps documented (open, Add-all, add custom, save, reload persistence, duplicate prevention); add unit tests for sanitization/dedupe and API mocks.
* [x] Docs: add short note in UI docs/README describing feature and the card-meta schema.

------
https://chatgpt.com/codex/tasks/task_e_68ccea61f43c8325bd44c1bf94383433