### PR TITLE
Add clipboard prompt management to card metadata drawer

### DIFF
--- a/tests/js/promptClipboard.test.mjs
+++ b/tests/js/promptClipboard.test.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '../../');
+
+const modulePath = path.join(rootDir, 'web/js/utils/promptClipboard.js');
+const {
+  parsePromptText,
+  sanitizePromptItems,
+  reorderItems,
+  formatPromptItems,
+  coerceSeparator,
+} = await import(modulePath);
+
+function testSanitizePromptItems() {
+  const values = ['  Foo  ', 'foo', 'BAR', 'bar', null, 'baz', 'baz', 'multi\r\nline'];
+  const result = sanitizePromptItems(values);
+  assert.deepEqual(result, ['Foo', 'BAR', 'baz', 'multi\nline']);
+}
+
+function testParsePromptText() {
+  const comma = parsePromptText('one, two,three', 'comma');
+  assert.deepEqual(comma, ['one', 'two', 'three']);
+  const newline = parsePromptText('alpha\n\n beta\r\ngamma');
+  assert.deepEqual(newline, ['alpha', 'beta', 'gamma']);
+  const pipe = parsePromptText('a|b|c|a', 'pipe');
+  assert.deepEqual(pipe, ['a', 'b', 'c']);
+}
+
+function testReorderItems() {
+  const source = ['one', 'two', 'three'];
+  const moved = reorderItems(source, 0, 2);
+  assert.deepEqual(moved, ['two', 'three', 'one']);
+  assert.deepEqual(source, ['one', 'two', 'three'], 'original array is not mutated');
+  const same = reorderItems(source, 5, 1);
+  assert.deepEqual(same, source);
+}
+
+function testFormatPromptItems() {
+  const items = ['one', 'two'];
+  assert.equal(formatPromptItems(items, 'comma'), 'one, two');
+  assert.equal(formatPromptItems(items, 'newline'), 'one\ntwo');
+  assert.equal(formatPromptItems([], 'newline'), '');
+}
+
+function testCoerceSeparator() {
+  assert.equal(coerceSeparator('comma'), 'comma');
+  assert.equal(coerceSeparator('unknown'), 'newline');
+}
+
+function run() {
+  testSanitizePromptItems();
+  testParsePromptText();
+  testReorderItems();
+  testFormatPromptItems();
+  testCoerceSeparator();
+  console.log('promptClipboard tests passed');
+}
+
+run();

--- a/tests/test_card_meta.py
+++ b/tests/test_card_meta.py
@@ -1,5 +1,7 @@
 import json
 import sys
+import json
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -21,12 +23,33 @@ def test_sanitize_custom_list_trims_and_dedupes():
     assert result == ['Foo', 'BAR', '123']
 
 
+def test_sanitize_prompt_items_preserves_order():
+    values = [' Foo ', 'bar', 'FOO', None, 'baz', 'baz ', 'multi\r\nline']
+    result = card_meta.sanitize_prompt_items(values)
+    assert result == ['Foo', 'bar', 'baz', 'multi\nline']
+
+
+def test_sanitize_prompt_groups_filters_invalid_entries():
+    groups = [
+        {'id': '  group-1  ', 'name': ' First ', 'items': ['One', 'one', 'two'], 'added_at': '2023-01-01'},
+        {'id': 'group-1', 'name': 'Duplicate', 'items': ['three']},
+        {'id': None, 'name': 'Missing id', 'items': ['ok']},
+        {'id': 'group-2', 'name': '', 'items': []},
+        'not-a-dict',
+    ]
+    sanitized = card_meta.sanitize_prompt_groups(groups)
+    assert sanitized == [
+        {'id': 'group-1', 'name': 'First', 'items': ['One', 'two'], 'added_at': '2023-01-01'}
+    ]
+
+
 def test_normalize_card_entry_sanitizes_binding_and_lists():
     entry = {
         'workflow_ids': ['wf1', 'WF1', '  '],
         'single_node_binding': {'node_type': '  Loader  ', 'widget': '  node  '},
         'custom_tags': ['Alpha', 'alpha', ''],
         'custom_triggers': ['Beta', None, 'beta'],
+        'custom_prompt_groups': [{'id': 'grp', 'name': 'Name', 'items': ['A', 'a']}],
         'extra_field': 5,
     }
     normalized = card_meta.normalize_card_entry(entry)
@@ -34,6 +57,7 @@ def test_normalize_card_entry_sanitizes_binding_and_lists():
     assert normalized['single_node_binding'] == {'node_type': 'Loader', 'widget': 'node'}
     assert normalized['custom_tags'] == ['Alpha']
     assert normalized['custom_triggers'] == ['Beta']
+    assert normalized['custom_prompt_groups'] == [{'id': 'grp', 'name': 'Name', 'items': ['A'] }]
     assert normalized['extra_field'] == 5
 
 
@@ -46,15 +70,19 @@ def test_update_card_custom_lists_persists(tmp_path: Path, monkeypatch: pytest.M
         'card123',
         custom_tags=[' Tag ', 'tag', 'Another'],
         custom_triggers=['Trigger', 'TRIGGER', ''],
+        custom_prompt_groups=[{'id': 'pg-1', 'name': 'Group', 'items': ['One', 'one', 'Two']}],
     )
     assert updated['custom_tags'] == ['Tag', 'Another']
     assert updated['custom_triggers'] == ['Trigger']
+    assert updated['custom_prompt_groups'] == [{'id': 'pg-1', 'name': 'Group', 'items': ['One', 'Two']}]
 
     data = card_meta.load_card_meta()
     assert data['cards']['card123']['custom_tags'] == ['Tag', 'Another']
     assert data['cards']['card123']['custom_triggers'] == ['Trigger']
+    assert data['cards']['card123']['custom_prompt_groups'] == [{'id': 'pg-1', 'name': 'Group', 'items': ['One', 'Two']}]
 
     with open(meta_path, 'r', encoding='utf-8') as handle:
         raw = json.load(handle)
     assert raw['cards']['card123']['custom_tags'] == ['Tag', 'Another']
     assert raw['cards']['card123']['custom_triggers'] == ['Trigger']
+    assert raw['cards']['card123']['custom_prompt_groups'] == [{'id': 'pg-1', 'name': 'Group', 'items': ['One', 'Two']}]

--- a/web/js/civitaiDownloader.css
+++ b/web/js/civitaiDownloader.css
@@ -1245,6 +1245,275 @@
     gap: 12px;
 }
 
+.civitai-card-meta-section.civitai-card-meta-clipboard,
+.civitai-card-meta-section.civitai-card-meta-groups {
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 10px;
+    padding: 14px;
+}
+
+.civitai-prompt-clipboard {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.civitai-prompt-clipboard-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.civitai-prompt-clipboard-title {
+    margin: 0;
+    font-size: 1.05em;
+}
+
+.civitai-prompt-clipboard-count {
+    font-size: 0.85em;
+    color: #a0aec0;
+}
+
+.civitai-prompt-clipboard-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+}
+
+.civitai-prompt-clipboard-label {
+    font-size: 0.85em;
+    color: #cbd5f5;
+}
+
+.civitai-prompt-clipboard-select {
+    background: var(--comfy-input-bg, #1e1e1e);
+    color: var(--comfy-text-color, #f1f1f1);
+    border: 1px solid var(--border-color, #4a4a4a);
+    border-radius: 6px;
+    padding: 6px 10px;
+    min-width: 140px;
+}
+
+.civitai-prompt-clipboard-actions {
+    display: flex;
+    gap: 6px;
+    margin-left: auto;
+}
+
+.civitai-prompt-clipboard-actions button,
+.civitai-clipboard-add,
+.civitai-clipboard-save {
+    background: var(--comfy-input-bg, #1f1f27);
+    border: 1px solid var(--border-color, #4b4b55);
+    color: var(--comfy-text-color, #f3f3f3);
+    border-radius: 6px;
+    padding: 6px 14px;
+    font-size: 0.85em;
+    cursor: pointer;
+    transition: background-color 0.2s ease, border-color 0.2s ease, transform 0.1s ease;
+}
+
+.civitai-prompt-clipboard-actions button.primary {
+    background: var(--accent-color, #5c8aff);
+    border-color: transparent;
+    color: #0b1024;
+}
+
+.civitai-prompt-clipboard-actions button:hover,
+.civitai-clipboard-add:hover,
+.civitai-clipboard-save:hover {
+    background: rgba(255, 255, 255, 0.06);
+    transform: translateY(-1px);
+}
+
+.civitai-prompt-clipboard-actions button.primary:hover {
+    background: var(--accent-color-hover, #7fa4ff);
+}
+
+.civitai-prompt-clipboard-actions button:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+    transform: none;
+}
+
+.civitai-prompt-clipboard-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    max-height: 260px;
+    overflow-y: auto;
+}
+
+.civitai-prompt-clipboard-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background: rgba(0, 0, 0, 0.2);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 8px;
+    padding: 6px 10px;
+}
+
+.civitai-prompt-clipboard-item.dragover {
+    border-color: var(--accent-color, #5c8aff);
+    box-shadow: inset 0 0 0 1px rgba(92, 138, 255, 0.35);
+}
+
+.civitai-prompt-clipboard-handle {
+    background: transparent;
+    border: none;
+    cursor: grab;
+    color: #9aa4bd;
+    font-size: 18px;
+    padding: 0 4px;
+}
+
+.civitai-prompt-clipboard-input {
+    flex: 1;
+    min-width: 120px;
+    background: var(--comfy-input-bg, #1e1e1e);
+    color: var(--comfy-text-color, #fff);
+    border: 1px solid var(--border-color, #4c4c4c);
+    border-radius: 6px;
+    padding: 6px 10px;
+}
+
+.civitai-prompt-clipboard-input:focus {
+    outline: none;
+    border-color: var(--accent-color, #5c8aff);
+    box-shadow: 0 0 0 2px rgba(92, 138, 255, 0.25);
+}
+
+.civitai-prompt-clipboard-item-actions {
+    display: flex;
+    gap: 4px;
+}
+
+.civitai-prompt-clipboard-item-actions button,
+.civitai-prompt-group-actions button {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    color: var(--comfy-text-color, #f5f5f5);
+    border-radius: 6px;
+    padding: 4px 8px;
+    font-size: 0.75em;
+    cursor: pointer;
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.civitai-prompt-clipboard-item-actions button:hover,
+.civitai-prompt-group-actions button:hover {
+    background: rgba(255, 255, 255, 0.08);
+    border-color: rgba(255, 255, 255, 0.15);
+}
+
+.civitai-prompt-clipboard-remove {
+    color: #ff9a9a;
+}
+
+.civitai-prompt-clipboard-remove:hover {
+    color: #ffc5c5;
+}
+
+.civitai-prompt-clipboard-empty {
+    padding: 12px;
+    text-align: center;
+    color: #9aa0b5;
+    background: rgba(0, 0, 0, 0.15);
+    border-radius: 8px;
+    border: 1px dashed rgba(255, 255, 255, 0.08);
+}
+
+.civitai-prompt-clipboard-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+}
+
+.civitai-prompt-groups-header {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.civitai-prompt-groups-header h4 {
+    margin: 0;
+}
+
+.civitai-prompt-groups-helper {
+    margin: 0;
+    font-size: 0.85em;
+    color: #9aa0b5;
+}
+
+.civitai-prompt-groups-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.civitai-prompt-group-empty {
+    padding: 10px;
+    text-align: center;
+    color: #9aa0b5;
+    background: rgba(0, 0, 0, 0.18);
+    border-radius: 8px;
+    border: 1px dashed rgba(255, 255, 255, 0.1);
+}
+
+.civitai-prompt-group-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 8px;
+    padding: 8px 12px;
+    transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.civitai-prompt-group-item:hover {
+    border-color: rgba(92, 138, 255, 0.5);
+    background: rgba(92, 138, 255, 0.1);
+}
+
+.civitai-prompt-group-load {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+    background: none;
+    border: none;
+    color: inherit;
+    text-align: left;
+    cursor: pointer;
+    padding: 0;
+}
+
+.civitai-prompt-group-name {
+    font-weight: 600;
+}
+
+.civitai-prompt-group-meta {
+    font-size: 0.75em;
+    color: #9aa0b5;
+}
+
+.civitai-prompt-group-actions {
+    display: flex;
+    gap: 6px;
+}
+
 .civitai-chip-editor {
     display: flex;
     flex-direction: column;

--- a/web/js/ui/chipEditor.js
+++ b/web/js/ui/chipEditor.js
@@ -190,7 +190,19 @@ export function createChipEditor(root, options = {}) {
   });
 
   if (addAllButton) {
-    addAllButton.addEventListener("click", () => {
+    addAllButton.addEventListener("click", async () => {
+      try {
+        if (typeof options.onAddAll === "function") {
+          const handled = await options.onAddAll([...state.source]);
+          if (handled) {
+            updateAddAllState();
+            inputEl.focus();
+            return;
+          }
+        }
+      } catch (error) {
+        console.warn("Chip editor onAddAll handler failed", error);
+      }
       addValues(state.source);
       updateAddAllState();
       inputEl.focus();

--- a/web/js/ui/promptClipboard.js
+++ b/web/js/ui/promptClipboard.js
@@ -1,0 +1,426 @@
+import {
+  CLIPBOARD_SEPARATOR_OPTIONS,
+  DEFAULT_SEPARATOR,
+  coerceSeparator,
+  formatPromptItems,
+  parsePromptText,
+  reorderItems,
+  sanitizePromptItems,
+} from "../utils/promptClipboard.js";
+import { copyTextToClipboard, readTextFromClipboard } from "../utils/clipboardAccess.js";
+
+let clipboardInstance = 0;
+
+export function createPromptClipboard(root, options = {}) {
+  if (!root) throw new Error("Prompt clipboard root element is required");
+  const instanceId = ++clipboardInstance;
+  const listId = `civitai-prompt-clipboard-list-${instanceId}`;
+  const separatorId = `civitai-prompt-clipboard-separator-${instanceId}`;
+  const targetId = `civitai-prompt-clipboard-target-${instanceId}`;
+  const titleId = `civitai-prompt-clipboard-title-${instanceId}`;
+
+  const targetOptions = Array.isArray(options.targets) && options.targets.length
+    ? options.targets
+    : [
+        { value: "triggers", label: "Custom triggers" },
+        { value: "tags", label: "Custom tags" },
+      ];
+
+  root.classList.add("civitai-prompt-clipboard");
+  root.innerHTML = `
+    <div class="civitai-prompt-clipboard-header">
+      <h4 id="${titleId}" class="civitai-prompt-clipboard-title">Clipboard</h4>
+      <span class="civitai-prompt-clipboard-count" aria-live="polite">0 items</span>
+    </div>
+    <div class="civitai-prompt-clipboard-toolbar" role="group" aria-labelledby="${titleId}">
+      <label class="civitai-prompt-clipboard-label" for="${separatorId}">
+        Separator
+      </label>
+      <select id="${separatorId}" class="civitai-prompt-clipboard-select" aria-label="Clipboard separator"></select>
+      <label class="civitai-prompt-clipboard-label" for="${targetId}">
+        Apply to
+      </label>
+      <select id="${targetId}" class="civitai-prompt-clipboard-select" aria-label="Clipboard apply target"></select>
+      <div class="civitai-prompt-clipboard-actions" role="group" aria-label="Clipboard actions">
+        <button type="button" class="civitai-clipboard-copy">Copy</button>
+        <button type="button" class="civitai-clipboard-paste">Paste</button>
+        <button type="button" class="civitai-clipboard-clear">Clear</button>
+        <button type="button" class="civitai-clipboard-apply primary">Apply</button>
+      </div>
+    </div>
+    <ul id="${listId}" class="civitai-prompt-clipboard-list" role="list" aria-describedby="${titleId}"></ul>
+    <div class="civitai-prompt-clipboard-footer">
+      <button type="button" class="civitai-clipboard-add">Add item</button>
+      <button type="button" class="civitai-clipboard-save">Save as prompt group</button>
+    </div>
+  `;
+
+  const listEl = root.querySelector(`#${listId}`);
+  const separatorSelect = root.querySelector(`#${separatorId}`);
+  const targetSelect = root.querySelector(`#${targetId}`);
+  const countEl = root.querySelector(".civitai-prompt-clipboard-count");
+  const copyButton = root.querySelector(".civitai-clipboard-copy");
+  const pasteButton = root.querySelector(".civitai-clipboard-paste");
+  const clearButton = root.querySelector(".civitai-clipboard-clear");
+  const applyButton = root.querySelector(".civitai-clipboard-apply");
+  const addButton = root.querySelector(".civitai-clipboard-add");
+  const saveButton = root.querySelector(".civitai-clipboard-save");
+
+  const onItemsChange = typeof options.onItemsChange === "function" ? options.onItemsChange : () => {};
+  const onApply = typeof options.onApply === "function" ? options.onApply : null;
+  const onSaveGroup = typeof options.onSaveGroup === "function" ? options.onSaveGroup : null;
+  const onToast = typeof options.onToast === "function" ? options.onToast : () => {};
+  const onTargetChange = typeof options.onTargetChange === "function" ? options.onTargetChange : () => {};
+
+  CLIPBOARD_SEPARATOR_OPTIONS.forEach((opt) => {
+    const option = document.createElement("option");
+    option.value = opt.value;
+    option.textContent = opt.label;
+    separatorSelect.appendChild(option);
+  });
+  separatorSelect.value = coerceSeparator(options.defaultSeparator);
+
+  targetOptions.forEach((opt) => {
+    const option = document.createElement("option");
+    option.value = opt.value;
+    option.textContent = opt.label;
+    targetSelect.appendChild(option);
+  });
+  targetSelect.value = targetOptions[0]?.value || "triggers";
+
+  const state = {
+    items: [],
+    separator: separatorSelect.value || DEFAULT_SEPARATOR,
+    target: targetSelect.value,
+  };
+
+  function updateCount() {
+    const count = state.items.filter((item) => String(item || "").trim()).length;
+    const label = count === 1 ? "1 item" : `${count} items`;
+    if (countEl) countEl.textContent = label;
+    const hasItems = count > 0;
+    copyButton.disabled = !hasItems;
+    clearButton.disabled = !hasItems;
+    applyButton.disabled = !hasItems;
+    saveButton.disabled = !hasItems;
+  }
+
+  function focusInput(index) {
+    const targetItem = listEl?.querySelector(`li[data-index="${index}"] input`);
+    if (targetItem) {
+      targetItem.focus();
+      targetItem.select();
+    }
+  }
+
+  function removeIndex(index) {
+    if (!Array.isArray(state.items)) return;
+    if (index < 0 || index >= state.items.length) return;
+    state.items.splice(index, 1);
+    renderList();
+    onItemsChange([...state.items]);
+    updateCount();
+  }
+
+  function moveIndex(from, to) {
+    const reordered = reorderItems(state.items, from, to);
+    state.items = reordered;
+    renderList();
+    onItemsChange([...state.items]);
+    updateCount();
+    focusInput(Math.max(0, Math.min(to, state.items.length - 1)));
+  }
+
+  function handleInputChange(event) {
+    const index = Number(event.currentTarget?.dataset?.index);
+    if (!Number.isInteger(index)) return;
+    const value = event.currentTarget.value;
+    state.items[index] = value;
+    onItemsChange([...state.items]);
+    updateCount();
+  }
+
+  function handleInputBlur(event) {
+    const index = Number(event.currentTarget?.dataset?.index);
+    if (!Number.isInteger(index)) return;
+    const value = String(event.currentTarget.value || "").trim();
+    if (!value) {
+      removeIndex(index);
+    } else {
+      state.items[index] = value;
+      renderList();
+      onItemsChange([...state.items]);
+      updateCount();
+    }
+  }
+
+  function addEmptyItem(focus = true) {
+    state.items.push("");
+    renderList();
+    onItemsChange([...state.items]);
+    updateCount();
+    if (focus) {
+      focusInput(state.items.length - 1);
+    }
+  }
+
+  function renderList() {
+    if (!listEl) return;
+    listEl.innerHTML = "";
+    state.items.forEach((raw, index) => {
+      const value = String(raw ?? "");
+      const item = document.createElement("li");
+      item.className = "civitai-prompt-clipboard-item";
+      item.setAttribute("role", "listitem");
+      item.dataset.index = String(index);
+      item.draggable = true;
+
+      const handle = document.createElement("button");
+      handle.type = "button";
+      handle.className = "civitai-prompt-clipboard-handle";
+      handle.setAttribute("aria-label", `Reorder item ${index + 1}`);
+      handle.innerHTML = "&#x2630;";
+      handle.addEventListener("click", () => {
+        focusInput(index);
+      });
+
+      const input = document.createElement("input");
+      input.type = "text";
+      input.value = value;
+      input.dataset.index = String(index);
+      input.className = "civitai-prompt-clipboard-input";
+      input.setAttribute("aria-label", `Clipboard item ${index + 1}`);
+      input.addEventListener("input", handleInputChange);
+      input.addEventListener("blur", handleInputBlur);
+      input.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" && !event.shiftKey && !event.ctrlKey) {
+          event.preventDefault();
+          addEmptyItem(true);
+        } else if ((event.altKey || event.ctrlKey) && event.key === "ArrowUp") {
+          event.preventDefault();
+          moveIndex(index, index - 1);
+        } else if ((event.altKey || event.ctrlKey) && event.key === "ArrowDown") {
+          event.preventDefault();
+          moveIndex(index, index + 1);
+        } else if (event.ctrlKey && event.key === "Enter") {
+          event.preventDefault();
+          applyCurrent();
+        }
+      });
+
+      const actions = document.createElement("div");
+      actions.className = "civitai-prompt-clipboard-item-actions";
+
+      const upBtn = document.createElement("button");
+      upBtn.type = "button";
+      upBtn.className = "civitai-prompt-clipboard-move";
+      upBtn.setAttribute("aria-label", `Move item ${index + 1} up`);
+      upBtn.textContent = "↑";
+      upBtn.disabled = index === 0;
+      upBtn.addEventListener("click", () => moveIndex(index, index - 1));
+
+      const downBtn = document.createElement("button");
+      downBtn.type = "button";
+      downBtn.className = "civitai-prompt-clipboard-move";
+      downBtn.setAttribute("aria-label", `Move item ${index + 1} down`);
+      downBtn.textContent = "↓";
+      downBtn.disabled = index === state.items.length - 1;
+      downBtn.addEventListener("click", () => moveIndex(index, index + 1));
+
+      const removeBtn = document.createElement("button");
+      removeBtn.type = "button";
+      removeBtn.className = "civitai-prompt-clipboard-remove";
+      removeBtn.setAttribute("aria-label", `Remove item ${index + 1}`);
+      removeBtn.innerHTML = "&times;";
+      removeBtn.addEventListener("click", () => {
+        removeIndex(index);
+      });
+
+      actions.appendChild(upBtn);
+      actions.appendChild(downBtn);
+      actions.appendChild(removeBtn);
+
+      item.appendChild(handle);
+      item.appendChild(input);
+      item.appendChild(actions);
+
+      item.addEventListener("dragstart", (event) => {
+        event.dataTransfer?.setData("text/plain", String(index));
+        event.dataTransfer?.setDragImage?.(item, 10, 10);
+        item.classList.add("dragging");
+      });
+      item.addEventListener("dragend", () => {
+        item.classList.remove("dragging");
+      });
+      item.addEventListener("dragover", (event) => {
+        event.preventDefault();
+        item.classList.add("dragover");
+      });
+      item.addEventListener("dragleave", () => item.classList.remove("dragover"));
+      item.addEventListener("drop", (event) => {
+        event.preventDefault();
+        item.classList.remove("dragover");
+        const fromIndex = Number(event.dataTransfer?.getData("text/plain"));
+        const toIndex = index;
+        if (Number.isInteger(fromIndex) && fromIndex !== toIndex) {
+          moveIndex(fromIndex, toIndex);
+        }
+      });
+
+      listEl.appendChild(item);
+    });
+    if (state.items.length === 0) {
+      const empty = document.createElement("li");
+      empty.className = "civitai-prompt-clipboard-empty";
+      empty.textContent = "Clipboard is empty";
+      empty.setAttribute("aria-live", "polite");
+      listEl.appendChild(empty);
+    }
+  }
+
+  async function copyCurrent() {
+    const formatted = formatPromptItems(state.items, state.separator);
+    if (!formatted) {
+      onToast("Nothing to copy", "info");
+      return;
+    }
+    const success = await copyTextToClipboard(formatted);
+    onToast(success ? "Copied to clipboard" : "Failed to copy", success ? "success" : "error");
+  }
+
+  async function pasteIntoClipboard() {
+    const text = await readTextFromClipboard();
+    if (!text) {
+      onToast("Clipboard was empty", "info");
+      return;
+    }
+    const parsed = parsePromptText(text, state.separator);
+    if (parsed.length === 0) {
+      onToast("No prompts found in clipboard", "info");
+      return;
+    }
+    state.items = sanitizePromptItems([...state.items, ...parsed], 256);
+    renderList();
+    onItemsChange([...state.items]);
+    updateCount();
+    onToast(`Added ${parsed.length} item${parsed.length === 1 ? "" : "s"} from clipboard`, "success");
+  }
+
+  function clearClipboard() {
+    if (!state.items.length) return;
+    state.items = [];
+    renderList();
+    onItemsChange([]);
+    updateCount();
+  }
+
+  async function applyCurrent(customItems = null) {
+    if (!onApply) return;
+    const sanitized = sanitizePromptItems(
+      customItems === null ? state.items : customItems,
+      256,
+    );
+    if (!sanitized.length) {
+      onToast("Clipboard is empty", "info");
+      return;
+    }
+    try {
+      await onApply(sanitized, { target: state.target, separator: state.separator });
+      onToast(`Applied ${sanitized.length} item${sanitized.length === 1 ? "" : "s"}`, "success");
+    } catch (error) {
+      console.warn("Clipboard apply failed", error);
+      onToast(error?.message || "Failed to apply clipboard", "error");
+    }
+  }
+
+  async function saveCurrent() {
+    if (!onSaveGroup) return;
+    const sanitized = sanitizePromptItems(state.items, 256);
+    if (!sanitized.length) {
+      onToast("Clipboard is empty", "info");
+      return;
+    }
+    try {
+      await onSaveGroup(sanitized, { target: state.target, separator: state.separator });
+    } catch (error) {
+      console.warn("Save prompt group failed", error);
+      onToast(error?.message || "Failed to save prompt group", "error");
+    }
+  }
+
+  separatorSelect.addEventListener("change", (event) => {
+    state.separator = coerceSeparator(event.target.value);
+  });
+
+  targetSelect.addEventListener("change", (event) => {
+    state.target = event.target.value;
+    onTargetChange(state.target);
+  });
+
+  copyButton.addEventListener("click", () => copyCurrent());
+  pasteButton.addEventListener("click", () => pasteIntoClipboard());
+  clearButton.addEventListener("click", () => clearClipboard());
+  applyButton.addEventListener("click", () => applyCurrent());
+  addButton.addEventListener("click", () => addEmptyItem(true));
+  saveButton.addEventListener("click", () => saveCurrent());
+
+  root.addEventListener("keydown", (event) => {
+    if (!event.ctrlKey && !event.metaKey) return;
+    if (event.shiftKey && event.code === "KeyC") {
+      event.preventDefault();
+      copyCurrent();
+    } else if (event.shiftKey && event.code === "KeyV") {
+      event.preventDefault();
+      pasteIntoClipboard();
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      applyCurrent();
+    }
+  });
+
+  renderList();
+  updateCount();
+
+  return {
+    getItems: ({ sanitized = false } = {}) =>
+      sanitized ? sanitizePromptItems(state.items, 256) : [...state.items],
+    setItems: (items, { append = false } = {}) => {
+      const sanitized = sanitizePromptItems(items, 256);
+      state.items = append
+        ? sanitizePromptItems([...state.items, ...sanitized], 256)
+        : sanitized;
+      renderList();
+      updateCount();
+      onItemsChange([...state.items]);
+    },
+    appendItems: (items) => {
+      const sanitized = sanitizePromptItems(items, 256);
+      if (!sanitized.length) return;
+      state.items = sanitizePromptItems([...state.items, ...sanitized], 256);
+      renderList();
+      updateCount();
+      onItemsChange([...state.items]);
+    },
+    clear: () => {
+      clearClipboard();
+    },
+    focus: () => {
+      focusInput(0);
+    },
+    isEmpty: () => state.items.length === 0,
+    getSeparator: () => state.separator,
+    setSeparator: (value) => {
+      const next = coerceSeparator(value);
+      state.separator = next;
+      separatorSelect.value = next;
+    },
+    getTarget: () => state.target,
+    setTarget: (value) => {
+      if (targetOptions.some((opt) => opt.value === value)) {
+        state.target = value;
+        targetSelect.value = value;
+      }
+    },
+    apply: (items) => applyCurrent(items ?? state.items),
+  };
+}

--- a/web/js/utils/clipboardAccess.js
+++ b/web/js/utils/clipboardAccess.js
@@ -1,0 +1,61 @@
+export async function copyTextToClipboard(text) {
+  const value = typeof text === "string" ? text : String(text ?? "");
+  if (!value) return false;
+  if (navigator?.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(value);
+      return true;
+    } catch (error) {
+      console.warn("Clipboard write failed, falling back", error);
+    }
+  }
+
+  try {
+    const textarea = document.createElement("textarea");
+    textarea.value = value;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "absolute";
+    textarea.style.left = "-9999px";
+    document.body.appendChild(textarea);
+    textarea.select();
+    const succeeded = document.execCommand("copy");
+    document.body.removeChild(textarea);
+    return succeeded;
+  } catch (error) {
+    console.warn("Legacy clipboard copy failed", error);
+    return false;
+  }
+}
+
+async function tryExecPaste() {
+  try {
+    const textarea = document.createElement("textarea");
+    textarea.setAttribute("aria-hidden", "true");
+    textarea.style.position = "absolute";
+    textarea.style.left = "-9999px";
+    document.body.appendChild(textarea);
+    textarea.focus();
+    const succeeded = document.execCommand && document.execCommand("paste");
+    const value = succeeded ? textarea.value : "";
+    document.body.removeChild(textarea);
+    if (succeeded) return value;
+  } catch (error) {
+    console.warn("execCommand paste fallback failed", error);
+  }
+  return "";
+}
+
+export async function readTextFromClipboard() {
+  if (navigator?.clipboard?.readText) {
+    try {
+      const text = await navigator.clipboard.readText();
+      if (typeof text === "string") return text;
+    } catch (error) {
+      console.warn("Clipboard read failed, falling back", error);
+    }
+  }
+  const pasted = await tryExecPaste();
+  if (pasted) return pasted;
+  const manual = window.prompt("Paste clipboard contents", "");
+  return typeof manual === "string" ? manual : "";
+}

--- a/web/js/utils/promptClipboard.js
+++ b/web/js/utils/promptClipboard.js
@@ -1,0 +1,107 @@
+const DEFAULT_SEPARATOR = "newline";
+
+export const CLIPBOARD_SEPARATOR_OPTIONS = [
+  { value: "newline", label: "New line" },
+  { value: "comma", label: "Comma" },
+  { value: "semicolon", label: "Semicolon" },
+  { value: "pipe", label: "Pipe" },
+];
+
+function getSeparatorPattern(key = DEFAULT_SEPARATOR) {
+  switch (key) {
+    case "comma":
+      return /[,\n]+/;
+    case "semicolon":
+      return /[;\n]+/;
+    case "pipe":
+      return /[|\n]+/;
+    case "newline":
+    default:
+      return /\r?\n+/;
+  }
+}
+
+export function coerceSeparator(value) {
+  if (CLIPBOARD_SEPARATOR_OPTIONS.some((opt) => opt.value === value)) {
+    return value;
+  }
+  return DEFAULT_SEPARATOR;
+}
+
+export function sanitizePromptItems(values, limit = 256) {
+  if (values == null) return [];
+  const list = Array.isArray(values) ? values : [values];
+  const maxItems = typeof limit === "number" && limit > 0 ? limit : 256;
+  const result = [];
+  const seen = new Set();
+  for (const raw of list) {
+    if (raw == null) continue;
+    let text = String(raw).replace(/\r/g, "").trim();
+    if (!text) continue;
+    if (text.length > 120) {
+      text = text.slice(0, 120).trim();
+    }
+    const lowered = text.toLocaleLowerCase();
+    if (seen.has(lowered)) continue;
+    seen.add(lowered);
+    result.push(text);
+    if (result.length >= maxItems) break;
+  }
+  return result;
+}
+
+export function parsePromptText(text, separator = DEFAULT_SEPARATOR) {
+  if (typeof text !== "string") return [];
+  const pattern = getSeparatorPattern(separator);
+  const pieces = text
+    .replace(/\r/g, "")
+    .split(pattern)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  return sanitizePromptItems(pieces, 256);
+}
+
+export function reorderItems(items, fromIndex, toIndex) {
+  if (!Array.isArray(items)) return [];
+  const list = items.slice();
+  const total = list.length;
+  if (total === 0) return [];
+  let from = Number(fromIndex);
+  let to = Number(toIndex);
+  if (!Number.isInteger(from) || !Number.isInteger(to)) return list;
+  if (from < 0 || from >= total) return list;
+  if (to < 0) to = 0;
+  if (to >= total) to = total - 1;
+  if (from === to) return list;
+  const [item] = list.splice(from, 1);
+  list.splice(to, 0, item);
+  return list;
+}
+
+export function formatPromptItems(items, separator = DEFAULT_SEPARATOR) {
+  const sanitized = sanitizePromptItems(items, 256);
+  if (sanitized.length === 0) return "";
+  switch (separator) {
+    case "comma":
+      return sanitized.join(", ");
+    case "semicolon":
+      return sanitized.join("; ");
+    case "pipe":
+      return sanitized.join(" | ");
+    case "newline":
+    default:
+      return sanitized.join("\n");
+  }
+}
+
+export function generatePromptGroupId(prefix = "pg") {
+  const base =
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  const trimmedPrefix = String(prefix || "pg").replace(/[^a-z0-9_-]/gi, "").slice(0, 16) || "pg";
+  const id = `${trimmedPrefix}-${base}`;
+  return id.slice(0, 80);
+}
+
+export { DEFAULT_SEPARATOR };


### PR DESCRIPTION
## Summary
- add a prompt clipboard panel with copy/paste/reorder controls to the card metadata drawer and wire Add all buttons to it
- allow saving, renaming, deleting, and applying per-card prompt groups backed by new clipboard utilities and metadata fields
- update backend sanitization, persistence, styles, and add unit tests (Python + Node) for prompt parsing and reorder logic

## Testing
- pytest
- node tests/js/promptClipboard.test.mjs

------
https://chatgpt.com/codex/tasks/task_e_68ccf8a04b0c8325afb8d359f5186224