### PR TITLE
Enable multi-file selection for Hugging Face downloads

### DIFF
--- a/web/js/civitaiDownloader.css
+++ b/web/js/civitaiDownloader.css
@@ -884,6 +884,21 @@
 .civi-file-row {
     font-size: 0.85rem;
 }
+.civi-select-all-row {
+    padding-bottom: 6px;
+    margin-bottom: 6px;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    font-weight: 600;
+}
+.civi-select-all-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.civi-select-count {
+    font-size: 0.75rem;
+    opacity: 0.7;
+}
 .civi-file-unavailable {
     opacity: 0.6;
     margin-left: 6px;


### PR DESCRIPTION
## Summary
- allow Hugging Face cards to toggle multiple file checkboxes with a Select All helper and shared folder defaults
- update queue handling to submit batches of Hugging Face payloads, report existing files, and surface combined status messaging
- add styling for the new Select All row in the file drawer

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d01ffb23a08325b0d8fee8c33e70ed